### PR TITLE
Chore/#4 Github Actions Npm publish

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - master
 
 jobs:
   publish-npm:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}


### PR DESCRIPTION
GitHub actions 에서 npm publish 용으로 많이 [사용되는 녀석](https://github.com/marketplace/actions/npm-publish)을 사용했습니다.

일단 테스트 step 같은 것은 아직 정해진 것이 없어 간단하게 Npm Registry 에 Publish 하는 것만 구현해두었습니다.