### PR TITLE
feat(ui-kit): Text 컴포넌트 디자인 변경

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -10,6 +10,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Set Git Configulations
+        run: |
+          git config --global user.email "lubycon@gmail.com"
+          git config --global user.name "lubycon"
       - name: Install depedencies
         run: yarn
       - name: Build Storybook

--- a/ui-kit/src/components/Text/index.stories.tsx
+++ b/ui-kit/src/components/Text/index.stories.tsx
@@ -16,7 +16,6 @@ const typographyNames: { [key in Typographys]: string } = {
   h5: '머릿말 5',
   h6: '머릿말 6',
   subtitle: '부제',
-  button: '버튼',
   content: '본문 1',
   content2: '본문 2',
   caption: '캡션',

--- a/ui-kit/src/components/Text/index.tsx
+++ b/ui-kit/src/components/Text/index.tsx
@@ -12,7 +12,7 @@ type TextProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridableProp
 
 const Text = <T extends ElementType = typeof DEFAULT_ELEMENT>(
   { typography = 'content', fontWeight = 'regular', as, ...props }: TextProps<T>,
-  ref: Ref<HTMLButtonElement>
+  ref: Ref<any>
 ) => {
   const target = as ?? DEFAULT_ELEMENT;
   const Component = target;

--- a/ui-kit/src/components/Text/index.tsx
+++ b/ui-kit/src/components/Text/index.tsx
@@ -11,7 +11,7 @@ interface TextBaseProps {
 type TextProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridableProps<T, TextBaseProps>;
 
 const Text = <T extends ElementType = typeof DEFAULT_ELEMENT>(
-  { typography = 'content', fontWeight, as, ...props }: TextProps<T>,
+  { typography = 'content', fontWeight = 'regular', as, ...props }: TextProps<T>,
   ref: Ref<HTMLButtonElement>
 ) => {
   const target = as ?? DEFAULT_ELEMENT;

--- a/ui-kit/src/components/Text/types.ts
+++ b/ui-kit/src/components/Text/types.ts
@@ -6,7 +6,6 @@ export const typographys = [
   'h5',
   'h6',
   'subtitle',
-  'button',
   'content',
   'content2',
   'caption',

--- a/ui-kit/src/sass/utils/_typography.scss
+++ b/ui-kit/src/sass/utils/_typography.scss
@@ -1,4 +1,4 @@
-@mixin _typography($name, $font-size, $font-weight, $line-height) {
+@mixin _typography($name, $font-size, $line-height) {
   $font-size-number: strip-unit($font-size);
 
   :root {
@@ -15,19 +15,16 @@
 
   .lubycon-typography--#{$name} {
     @extend .lubycon-font-size--#{$font-size-number};
-    @extend .lubycon-font-weight--#{$font-weight};
   }
 }
 
-@include _typography('h1', 42px, 'light', 63px);
-@include _typography('h2', 32px, 'light', 48px);
-@include _typography('h3', 28px, 'regular', 42px);
-@include _typography('h4', 26px, 'regular', 40px);
-@include _typography('h5', 24px, 'bold', 40px);
-@include _typography('h6', 20px, 'bold', 40px);
-
-@include _typography('subtitle', 18px, 'regular', 31px);
-@include _typography('button', 16px, 'bold', 28px);
-@include _typography('content', 15px, 'regular', 26px);
-@include _typography('content2', 13px, 'regular', 22px);
-@include _typography('caption', 12px, 'regular', 21px);
+@include _typography('h1', 42px, 63px);
+@include _typography('h2', 32px, 48px);
+@include _typography('h3', 28px, 42px);
+@include _typography('h4', 26px, 40px);
+@include _typography('h5', 24px, 36px);
+@include _typography('h6', 20px, 30px);
+@include _typography('subtitle', 18px, 31px);
+@include _typography('content', 16px, 28px);
+@include _typography('content2', 15px, 26px);
+@include _typography('caption', 12px, 21px);


### PR DESCRIPTION
## 주요 변경사항
- Text 컴포넌트의 `font-size`와 `line-height`가 변경되고, 타이포그래피 속성에서 `font-weight`가 제거되었습니다.
- Text 컴포넌트의 `fontWeight`의 default paramter로 `regular`가 지정됩니다.
- `button` 타이포그래피가 제거됩니다.
- 스토리북 배포 스크립트에서 깃 유저 없어서 찐빠나는 거 수정

## 링크
- 디자인 시안 링크: https://www.figma.com/file/TxkDTIYPl6ygZUr5ZQ9yQ8/Lubycon-UI-Library_2?node-id=42%3A138

## 시급한 정도
🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

## 중점적으로 봐주었으면 하는 부분
🙇‍♂️
