### PR TITLE
feat(ui-kit): Radio 컴포넌트 추가

### DIFF
--- a/ui-kit/src/components/Radio/index.tsx
+++ b/ui-kit/src/components/Radio/index.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef } from 'react';
+import { Ref } from 'react';
+import { CombineElementProps } from 'src/types/utils';
+import clxs from 'classnames';
+import { generateID } from 'src/utils/generateID';
+import { Text } from '..';
+
+interface RadioBaseProps {
+  label?: string;
+  display?: 'block' | 'inline';
+}
+type RadioProps = Omit<CombineElementProps<'input', RadioBaseProps>, 'type'>;
+
+const RadioOption = (
+  { label, display = 'block', ...props }: RadioProps,
+  ref: Ref<HTMLInputElement>
+) => {
+  const id = generateID('radio-option');
+
+  return (
+    <span className={clxs('lubycon-radio', `lubycon-radio--display-${display}`)}>
+      <input ref={ref} type="radio" {...props} id={id} />
+      {label ? (
+        <Text as="label" htmlFor={id}>
+          {label}
+        </Text>
+      ) : null}
+    </span>
+  );
+};
+
+export default forwardRef(RadioOption) as typeof RadioOption;

--- a/ui-kit/src/components/Radio/index.tsx
+++ b/ui-kit/src/components/Radio/index.tsx
@@ -11,15 +11,28 @@ interface RadioBaseProps {
 }
 type RadioProps = Omit<CombineElementProps<'input', RadioBaseProps>, 'type'>;
 
-const RadioOption = (
-  { label, display = 'block', ...props }: RadioProps,
+const Radio = (
+  { label, display = 'block', style, disabled, ...props }: RadioProps,
   ref: Ref<HTMLInputElement>
 ) => {
-  const id = generateID('radio-option');
+  const id = generateID('radio');
 
   return (
-    <span className={clxs('lubycon-radio', `lubycon-radio--display-${display}`)}>
-      <input ref={ref} type="radio" {...props} id={id} />
+    <span
+      className={clxs('lubycon-radio', `lubycon-radio--display-${display}`, {
+        'lubycon-radio--disabled': disabled,
+      })}
+      style={style}
+    >
+      <input
+        className="lubycon-radio--input"
+        ref={ref}
+        type="radio"
+        disabled={disabled}
+        {...props}
+        id={id}
+      />
+      <div className="lubycon-radio--indicator"></div>
       {label ? (
         <Text as="label" htmlFor={id}>
           {label}
@@ -29,4 +42,4 @@ const RadioOption = (
   );
 };
 
-export default forwardRef(RadioOption) as typeof RadioOption;
+export default forwardRef(Radio) as typeof Radio;

--- a/ui-kit/src/sass/components/_Radio.scss
+++ b/ui-kit/src/sass/components/_Radio.scss
@@ -1,15 +1,74 @@
+// 추후 color로 변경
+$gray: #b5b6b9;
+$blue: #437cea;
+
+$indicator-size: 16px;
+
 .lubycon-radio {
   position: relative;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
 
-  &--display-block {
-    display: block;
+  label {
+    cursor: pointer;
   }
+
+  .lubycon-radio--indicator {
+    position: relative;
+    width: $indicator-size;
+    height: $indicator-size;
+    border: 1px solid $gray;
+    margin-right: 10px;
+    border-radius: 50%;
+    overflow: hidden;
+    &::before {
+      content: '';
+      width: $indicator-size / 2;
+      height: $indicator-size / 2;
+      position: absolute;
+      background-color: #ffffff;
+      border-radius: 50%;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0);
+      transition: transform 0.3s ease-in-out;
+    }
+  }
+
+  .lubycon-radio--input {
+    position: absolute;
+    visibility: hidden;
+    appearance: none;
+    &:checked + .lubycon-radio--indicator {
+      border-color: $blue;
+      background-color: $blue;
+      &::before {
+        transform: translate(-50%, -50%) scale(1);
+      }
+    }
+  }
+
+  &:hover:not(&--disabled) {
+    .lubycon-radio--indicator {
+      border-color: $blue;
+    }
+  }
+
   &--display-inline {
-    display: inline-block;
+    display: inline-flex;
   }
 
-  input[type='radio'] {
-    display: none;
+  &--disabled {
+    cursor: not-allowed;
+    label {
+      color: $gray;
+      cursor: not-allowed;
+    }
+    .lubycon-radio--input:checked + .lubycon-radio--indicator {
+      border-color: $gray;
+      background-color: $gray;
+    }
   }
 }

--- a/ui-kit/src/sass/components/_Radio.scss
+++ b/ui-kit/src/sass/components/_Radio.scss
@@ -1,0 +1,15 @@
+.lubycon-radio {
+  position: relative;
+  cursor: pointer;
+
+  &--display-block {
+    display: block;
+  }
+  &--display-inline {
+    display: inline-block;
+  }
+
+  input[type='radio'] {
+    display: none;
+  }
+}

--- a/ui-kit/src/sass/components/_index.scss
+++ b/ui-kit/src/sass/components/_index.scss
@@ -1,2 +1,3 @@
 @import './Button';
 @import './Text';
+@import './Radio';

--- a/ui-kit/src/stories/Radio.stories.tsx
+++ b/ui-kit/src/stories/Radio.stories.tsx
@@ -10,8 +10,28 @@ export default {
 export const Default = () => {
   return (
     <div>
-      <Radio label="라디오1" />
-      <Radio label="라디오2" />
+      <Radio label="라디오1" name="radio" />
+      <Radio label="라디오2" name="radio" />
+    </div>
+  );
+};
+
+export const Disabled = () => {
+  return (
+    <div>
+      <Radio label="라디오1" name="radio" />
+      <Radio label="라디오2" name="radio" />
+      <Radio label="라디오3" name="radio" disabled />
+      <Radio label="라디오4" name="radio" defaultChecked={true} disabled />
+    </div>
+  );
+};
+
+export const Inline = () => {
+  return (
+    <div>
+      <Radio display="inline" label="라디오1" name="radio" style={{ marginRight: 16 }} />
+      <Radio display="inline" label="라디오2" name="radio" />
     </div>
   );
 };

--- a/ui-kit/src/stories/Radio.stories.tsx
+++ b/ui-kit/src/stories/Radio.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Radio from 'components/Radio';
+import { Meta } from '@storybook/react/types-6-0';
+
+export default {
+  title: 'Lubycon UI Kit/Radio',
+  component: Radio,
+} as Meta;
+
+export const Default = () => {
+  return (
+    <div>
+      <Radio label="라디오1" />
+      <Radio label="라디오2" />
+    </div>
+  );
+};

--- a/ui-kit/src/types/utils.ts
+++ b/ui-kit/src/types/utils.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ElementType } from 'react';
+import { ComponentPropsWithoutRef, ComponentType, ElementType, ReactElement } from 'react';
 
 /**
  * @description T와 K에서 T의 프로퍼티를 제거한 타입을 병합합니다.
@@ -9,3 +9,5 @@ export type CombineElementProps<E extends ElementType, P = unknown> = Combine<
   P,
   ComponentPropsWithoutRef<E>
 >;
+
+export type ComponentElementType<T> = ReactElement<ComponentType<T>>;

--- a/ui-kit/src/utils/generateID.ts
+++ b/ui-kit/src/utils/generateID.ts
@@ -1,0 +1,4 @@
+export function generateID(prefix: string) {
+  const now = new Date().getTime();
+  return `${prefix}-${now}`;
+}

--- a/ui-kit/src/utils/generateID.ts
+++ b/ui-kit/src/utils/generateID.ts
@@ -1,4 +1,6 @@
+let idIndex = 0;
+
 export function generateID(prefix: string) {
-  const now = new Date().getTime();
-  return `${prefix}-${now}`;
+  idIndex++;
+  return `${prefix}-${idIndex}`;
 }


### PR DESCRIPTION
## 주요 변경사항
![스크린샷 2020-12-08 오전 12 58 15](https://user-images.githubusercontent.com/19145342/101373630-833c3680-38f0-11eb-9789-e53dc6f8f660.png)

Radio 컴포넌트가 추가되었습니다. 현재 `color`가 없기 때문에 일단 scss 변수로 때려넣었습니다. 추후 @Junkim93 님 작업 완료되시면 반영하겠읍니다 🙏

## 링크
- 디자인 시안 링크: https://www.figma.com/file/TxkDTIYPl6ygZUr5ZQ9yQ8/Lubycon-UI-Library_2?node-id=0%3A1

## 시급한 정도
🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

## 중점적으로 봐주었으면 하는 부분
`generateID` 함수를 헤비하게 짤 필요가 없는 것 같아서 그냥 모듈 스코프에서 `number` 값을 1씩 증가시키는 것으로 해결했는데, 이거 해싱을 쓰는게 나을까요...?
