### PR TITLE
feat(ui-kit): Selection 컴포넌트 추가

### DIFF
--- a/ui-kit/package.json
+++ b/ui-kit/package.json
@@ -22,7 +22,8 @@
   "author": "Lubycon",
   "dependencies": {
     "@types/classnames": "^2.2.11",
-    "classnames": "^2.2.6"
+    "classnames": "^2.2.6",
+    "ionicons": "^5.2.3"
   },
   "scripts": {
     "start": "start-storybook -p 6006 --no-dll",
@@ -74,8 +75,8 @@
     "@types/react-dom": "^16.9.8",
     "autoprefixer": "^9.0.0",
     "babel-loader": "^8.2.1",
-    "gh-pages": "^3.1.0",
     "classnames": "^2.2.6",
+    "gh-pages": "^3.1.0",
     "postcss": "^7.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/ui-kit/package.json
+++ b/ui-kit/package.json
@@ -35,7 +35,8 @@
     "clean": "rm -rf dist && mkdir dist",
     "copy": "ncp package.json dist/package.json",
     "copy-sass": "ncp src/sass/modules dist/sass",
-    "copy-version": "ncp dist/package.json package.json"
+    "copy-version": "ncp dist/package.json package.json",
+    "typecheck": "tsc --noEmit"
   },
   "eslintConfig": {
     "extends": [

--- a/ui-kit/src/components/Checkbox/index.tsx
+++ b/ui-kit/src/components/Checkbox/index.tsx
@@ -46,4 +46,4 @@ const Checkbox = (
   );
 };
 
-export default forwardRef(Checkbox) as typeof Checkbox;
+export default forwardRef(Checkbox);

--- a/ui-kit/src/components/Checkbox/index.tsx
+++ b/ui-kit/src/components/Checkbox/index.tsx
@@ -1,5 +1,4 @@
-import React, { forwardRef } from 'react';
-import { Ref } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import { CombineElementProps } from 'src/types/utils';
 import classnames from 'classnames';
 import { generateID } from 'utils/index';
@@ -46,4 +45,4 @@ const Checkbox = (
   );
 };
 
-export default forwardRef(Checkbox);
+export default forwardRef(Checkbox) as typeof Checkbox;

--- a/ui-kit/src/components/Container/index.tsx
+++ b/ui-kit/src/components/Container/index.tsx
@@ -4,6 +4,6 @@ interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
   size: 'fluid' | 'sm' | 'md' | 'lg' | 'xl';
 }
 
-export default function Container({ size, ...props }: ContainerProps): JSX.Element {
+export default function Container({ ...props }: ContainerProps): JSX.Element {
   return <div>{props.children}</div>;
 }

--- a/ui-kit/src/components/Container/style.scss
+++ b/ui-kit/src/components/Container/style.scss
@@ -1,2 +1,0 @@
-.container {
-}

--- a/ui-kit/src/components/Grid/Column.tsx
+++ b/ui-kit/src/components/Grid/Column.tsx
@@ -16,7 +16,7 @@ type ColumnProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridablePr
 
 const Column = <T extends React.ElementType = typeof DEFAULT_ELEMENT>(
   { as, ...props }: ColumnProps<T>,
-  ref: React.Ref<T>
+  ref: React.Ref<any>
 ) => {
   const spanClasses = useMemo(
     () =>
@@ -35,4 +35,4 @@ const Column = <T extends React.ElementType = typeof DEFAULT_ELEMENT>(
   );
 };
 
-export default React.forwardRef(Column);
+export default React.forwardRef(Column) as typeof Column;

--- a/ui-kit/src/components/Grid/Column.tsx
+++ b/ui-kit/src/components/Grid/Column.tsx
@@ -16,7 +16,7 @@ type ColumnProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridablePr
 
 const Column = <T extends React.ElementType = typeof DEFAULT_ELEMENT>(
   { as, ...props }: ColumnProps<T>,
-  ref: React.Ref<any>
+  ref: React.Ref<T>
 ) => {
   const spanClasses = useMemo(
     () =>
@@ -35,4 +35,4 @@ const Column = <T extends React.ElementType = typeof DEFAULT_ELEMENT>(
   );
 };
 
-export default React.forwardRef(Column) as typeof Column;
+export default React.forwardRef(Column);

--- a/ui-kit/src/components/Grid/Row.tsx
+++ b/ui-kit/src/components/Grid/Row.tsx
@@ -11,9 +11,15 @@ interface RowBaseProps {
 }
 type RowProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridableProps<T, RowBaseProps>;
 
-const Row = (
-  { as, direction = 'row', justify = 'flex-start', alignItems = 'flex-start', ...props }: RowProps,
-  ref: Ref<any>
+const Row = <T extends ElementType = typeof DEFAULT_ELEMENT>(
+  {
+    as,
+    direction = 'row',
+    justify = 'flex-start',
+    alignItems = 'flex-start',
+    ...props
+  }: RowProps<T>,
+  ref: Ref<T>
 ) => {
   const Component = as ?? DEFAULT_ELEMENT;
 
@@ -31,4 +37,4 @@ const Row = (
   );
 };
 
-export default forwardRef(Row) as typeof Row;
+export default forwardRef(Row);

--- a/ui-kit/src/components/Grid/Row.tsx
+++ b/ui-kit/src/components/Grid/Row.tsx
@@ -19,7 +19,7 @@ const Row = <T extends ElementType = typeof DEFAULT_ELEMENT>(
     alignItems = 'flex-start',
     ...props
   }: RowProps<T>,
-  ref: Ref<T>
+  ref: Ref<any>
 ) => {
   const Component = as ?? DEFAULT_ELEMENT;
 
@@ -37,4 +37,4 @@ const Row = <T extends ElementType = typeof DEFAULT_ELEMENT>(
   );
 };
 
-export default forwardRef(Row);
+export default forwardRef(Row) as typeof Row;

--- a/ui-kit/src/components/Icon/index.tsx
+++ b/ui-kit/src/components/Icon/index.tsx
@@ -1,0 +1,35 @@
+import React, { useMemo } from 'react';
+import classnames from 'classnames';
+import { Colors, colors } from 'src/constants/colors';
+
+/**
+ * UI Kit 내부에서만 사용
+ */
+
+interface Props {
+  icon: string;
+  size?: number;
+  type: 'outline' | 'filled';
+  color?: Colors;
+}
+
+const Icon = ({ icon, size = 16, type, color = colors.gray100 }: Props) => {
+  const svg = useMemo(() => {
+    const tag = icon.replace(/data:image\/svg\+xml;utf8,/, '');
+    const targetAttr = type === 'outline' ? 'stroke' : 'fill';
+    return tag.replace(/(<path\s)\b/gm, `$1${targetAttr}="${color}" `);
+  }, [icon]);
+
+  return (
+    <span
+      className={classnames('lubycon-icon', {
+        'lubycon-icon--outline': type === 'outline',
+        'lubycon-icon--filled': type === 'filled',
+      })}
+      style={{ width: size, height: size }}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+};
+
+export default Icon;

--- a/ui-kit/src/components/Icon/index.tsx
+++ b/ui-kit/src/components/Icon/index.tsx
@@ -14,11 +14,14 @@ interface Props {
 }
 
 const Icon = ({ icon, size = 16, type, color = colors.gray100 }: Props) => {
-  const svg = useMemo(() => {
-    const tag = icon.replace(/data:image\/svg\+xml;utf8,/, '');
-    const targetAttr = type === 'outline' ? 'stroke' : 'fill';
-    return tag.replace(/(<path\s)\b/gm, `$1${targetAttr}="${color}" `);
+  const svgTag = useMemo(() => {
+    return icon.replace(/data:image\/svg\+xml;utf8,/, '');
   }, [icon]);
+
+  const coloredSvg = useMemo(() => {
+    const targetAttr = type === 'outline' ? 'stroke' : 'fill';
+    return svgTag.replace(/(<path\s)\b/gm, `$1${targetAttr}="${color}" `);
+  }, [svgTag, color]);
 
   return (
     <span
@@ -27,7 +30,7 @@ const Icon = ({ icon, size = 16, type, color = colors.gray100 }: Props) => {
         'lubycon-icon--filled': type === 'filled',
       })}
       style={{ width: size, height: size }}
-      dangerouslySetInnerHTML={{ __html: svg }}
+      dangerouslySetInnerHTML={{ __html: coloredSvg }}
     />
   );
 };

--- a/ui-kit/src/components/Radio/index.tsx
+++ b/ui-kit/src/components/Radio/index.tsx
@@ -1,5 +1,4 @@
-import React, { forwardRef } from 'react';
-import { Ref } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import { CombineElementProps } from 'src/types/utils';
 import clxs from 'classnames';
 import { generateID } from 'src/utils/generateID';
@@ -40,4 +39,4 @@ const Radio = (
   );
 };
 
-export default forwardRef(Radio);
+export default forwardRef(Radio) as typeof Radio;

--- a/ui-kit/src/components/Radio/index.tsx
+++ b/ui-kit/src/components/Radio/index.tsx
@@ -40,4 +40,4 @@ const Radio = (
   );
 };
 
-export default forwardRef(Radio) as typeof Radio;
+export default forwardRef(Radio);

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -2,7 +2,9 @@ import React, { forwardRef } from 'react';
 import { Ref } from 'react';
 import { CombineElementProps } from 'src/types/utils';
 import classnames from 'classnames';
-
+import { chevronDownOutline } from 'ionicons/icons';
+import Icon from 'components/Icon';
+import { colors } from 'src/constants/colors';
 interface SelectionBaseProps {
   placeholder?: string;
 }
@@ -12,23 +14,22 @@ const Selection = (
   { placeholder, disabled, children, ...props }: SelectionProps,
   ref: Ref<any>
 ) => {
-  console.log(placeholder);
   return (
-    <select
-      ref={ref}
-      multiple={false}
-      {...props}
+    <div
       className={classnames('lubycon-selection', {
         'lubycon-selection--disabled': disabled,
       })}
     >
-      {placeholder !== undefined ? (
-        <option value="" hidden={true}>
-          {placeholder}
-        </option>
-      ) : null}
-      {children}
-    </select>
+      <select ref={ref} multiple={false} {...props} className="lubycon-selection--select">
+        {placeholder !== undefined ? (
+          <option value="" hidden={true} className="lubycon-selection--placeholder">
+            {placeholder}
+          </option>
+        ) : null}
+        {children}
+      </select>
+      <Icon icon={chevronDownOutline} type="outline" color={colors.gray40} />
+    </div>
   );
 };
 

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -1,0 +1,35 @@
+import React, { forwardRef } from 'react';
+import { Ref } from 'react';
+import { CombineElementProps } from 'src/types/utils';
+import classnames from 'classnames';
+
+interface SelectionBaseProps {
+  placeholder?: string;
+}
+type SelectionProps = Omit<CombineElementProps<'select', SelectionBaseProps>, 'multiple'>;
+
+const Selection = (
+  { placeholder, disabled, children, ...props }: SelectionProps,
+  ref: Ref<any>
+) => {
+  console.log(placeholder);
+  return (
+    <select
+      ref={ref}
+      multiple={false}
+      {...props}
+      className={classnames('lubycon-selection', {
+        'lubycon-selection--disabled': disabled,
+      })}
+    >
+      {placeholder !== undefined ? (
+        <option value="" hidden={true}>
+          {placeholder}
+        </option>
+      ) : null}
+      {children}
+    </select>
+  );
+};
+
+export default forwardRef(Selection) as typeof Selection;

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -7,6 +7,7 @@ import { colors } from 'src/constants/colors';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import { Typographys } from '../Text/types';
+
 interface SelectionBaseProps {
   placeholder?: string;
   size?: 'small' | 'medium' | 'large';

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -1,5 +1,4 @@
-import React, { forwardRef } from 'react';
-import { Ref } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import { CombineElementProps } from 'src/types/utils';
 import classnames from 'classnames';
 import { chevronDownOutline } from 'ionicons/icons';
@@ -60,4 +59,4 @@ const Selection = (
   );
 };
 
-export default forwardRef(Selection);
+export default forwardRef(Selection) as typeof Selection;

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -24,7 +24,7 @@ const Selection = (
     size = 'medium',
     ...props
   }: SelectionProps,
-  ref: Ref<any>
+  ref: Ref<HTMLSelectElement>
 ) => {
   const [innerValue, setInnerValue] = useState(value ?? '');
   const iconColor = disabled ? colors.gray60 : colors.gray40;
@@ -60,4 +60,4 @@ const Selection = (
   );
 };
 
-export default forwardRef(Selection) as typeof Selection;
+export default forwardRef(Selection);

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -5,30 +5,57 @@ import classnames from 'classnames';
 import { chevronDownOutline } from 'ionicons/icons';
 import Icon from 'components/Icon';
 import { colors } from 'src/constants/colors';
+import { useState } from 'react';
+import { useEffect } from 'react';
+import { Typographys } from '../Text/types';
 interface SelectionBaseProps {
   placeholder?: string;
+  size?: 'small' | 'medium' | 'large';
 }
 type SelectionProps = Omit<CombineElementProps<'select', SelectionBaseProps>, 'multiple'>;
 
 const Selection = (
-  { placeholder, disabled, children, ...props }: SelectionProps,
+  {
+    placeholder = '옵션을 선택하세요',
+    disabled,
+    children,
+    value,
+    onChange,
+    size = 'medium',
+    ...props
+  }: SelectionProps,
   ref: Ref<any>
 ) => {
+  const [innerValue, setInnerValue] = useState(value ?? '');
+  const iconColor = disabled ? colors.gray60 : colors.gray40;
+  const typography: Typographys = size === 'large' ? 'content' : 'content2';
+
+  useEffect(() => setInnerValue(value ?? ''), [value]);
+
   return (
     <div
-      className={classnames('lubycon-selection', {
+      className={classnames('lubycon-selection', `lubycon-selection--size-${size}`, {
         'lubycon-selection--disabled': disabled,
+        'lubycon-selection--empty': innerValue === '',
       })}
     >
-      <select ref={ref} multiple={false} {...props} className="lubycon-selection--select">
-        {placeholder !== undefined ? (
-          <option value="" hidden={true} className="lubycon-selection--placeholder">
-            {placeholder}
-          </option>
-        ) : null}
+      <select
+        ref={ref}
+        multiple={false}
+        {...props}
+        value={innerValue}
+        className={classnames('lubycon-selection__select', `lubycon-typography--${typography}`)}
+        onChange={(e) => {
+          onChange?.(e);
+          setInnerValue(e.target.value ?? '');
+        }}
+      >
+        <option value="" hidden={true} className="lubycon-selection__placeholder">
+          {placeholder}
+        </option>
         {children}
       </select>
-      <Icon icon={chevronDownOutline} type="outline" color={colors.gray40} />
+      <Icon icon={chevronDownOutline} type="outline" color={iconColor} />
     </div>
   );
 };

--- a/ui-kit/src/components/Switch/index.tsx
+++ b/ui-kit/src/components/Switch/index.tsx
@@ -30,4 +30,4 @@ const Switch = (
   );
 };
 
-export default forwardRef(Switch) as typeof Switch;
+export default forwardRef(Switch);

--- a/ui-kit/src/components/Switch/index.tsx
+++ b/ui-kit/src/components/Switch/index.tsx
@@ -1,5 +1,4 @@
-import React, { forwardRef } from 'react';
-import { Ref } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import { CombineElementProps } from 'src/types/utils';
 import clxs from 'classnames';
 import { generateID } from 'src/utils/generateID';
@@ -30,4 +29,4 @@ const Switch = (
   );
 };
 
-export default forwardRef(Switch);
+export default forwardRef(Switch) as typeof Switch;

--- a/ui-kit/src/components/Text/index.tsx
+++ b/ui-kit/src/components/Text/index.tsx
@@ -12,7 +12,7 @@ type TextProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridableProp
 
 const Text = <T extends ElementType = typeof DEFAULT_ELEMENT>(
   { typography = 'content', fontWeight = 'regular', as, ...props }: TextProps<T>,
-  ref: Ref<any>
+  ref: Ref<T>
 ) => {
   const target = as ?? DEFAULT_ELEMENT;
   const Component = target;
@@ -28,4 +28,4 @@ const Text = <T extends ElementType = typeof DEFAULT_ELEMENT>(
   );
 };
 
-export default forwardRef(Text) as typeof Text;
+export default forwardRef(Text);

--- a/ui-kit/src/components/Text/index.tsx
+++ b/ui-kit/src/components/Text/index.tsx
@@ -1,6 +1,5 @@
-import React, { ElementType, Ref } from 'react';
+import React, { ElementType, Ref, forwardRef } from 'react';
 import { DEFAULT_ELEMENT, FontWeights, Typographys } from './types';
-import { forwardRef } from 'react';
 import { OverridableProps } from 'types/OverridableProps';
 import clxs from 'classnames';
 
@@ -12,7 +11,7 @@ type TextProps<T extends ElementType = typeof DEFAULT_ELEMENT> = OverridableProp
 
 const Text = <T extends ElementType = typeof DEFAULT_ELEMENT>(
   { typography = 'content', fontWeight = 'regular', as, ...props }: TextProps<T>,
-  ref: Ref<T>
+  ref: Ref<any>
 ) => {
   const target = as ?? DEFAULT_ELEMENT;
   const Component = target;
@@ -28,4 +27,4 @@ const Text = <T extends ElementType = typeof DEFAULT_ELEMENT>(
   );
 };
 
-export default forwardRef(Text);
+export default forwardRef(Text) as typeof Text;

--- a/ui-kit/src/components/index.ts
+++ b/ui-kit/src/components/index.ts
@@ -1,5 +1,8 @@
 export { default as Button } from './Button';
-export { default as Text } from './Text';
-export { Row, Column } from './Grid';
 export { default as Checkbox } from './Checkbox';
+export { default as Container } from './Container';
+export { Row, Column } from './Grid';
+export { default as Radio } from './Radio';
+export { default as Selection } from './Selection';
 export { default as Switch } from './Switch';
+export { default as Text } from './Text';

--- a/ui-kit/src/components/index.ts
+++ b/ui-kit/src/components/index.ts
@@ -1,6 +1,5 @@
 export { default as Button } from './Button';
 export { default as Checkbox } from './Checkbox';
-export { default as Container } from './Container';
 export { Row, Column } from './Grid';
 export { default as Radio } from './Radio';
 export { default as Selection } from './Selection';

--- a/ui-kit/src/sass/components/_Icon.scss
+++ b/ui-kit/src/sass/components/_Icon.scss
@@ -1,0 +1,17 @@
+.lubycon-icon {
+  display: inline-block;
+  &--outline {
+    path {
+      fill: transparent;
+    }
+  }
+  &--filled {
+    path {
+      stroke: transparent;
+    }
+  }
+  svg {
+    width: 100%;
+    vertical-align: top;
+  }
+}

--- a/ui-kit/src/sass/components/_Selection.scss
+++ b/ui-kit/src/sass/components/_Selection.scss
@@ -1,0 +1,24 @@
+.lubycon-selection {
+  position: relative;
+  display: inline-block;
+  background-color: white;
+  border: 1px solid get-color('gray30');
+  border-radius: 8px;
+
+  .lubycon-selection--select {
+    width: 100%;
+    background-color: transparent;
+    appearance: none;
+    outline: none;
+    border: none;
+    padding: 8px 36px 8px 16px;
+  }
+
+  .lubycon-icon {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    stroke: get-color('grey40');
+  }
+}

--- a/ui-kit/src/sass/components/_Selection.scss
+++ b/ui-kit/src/sass/components/_Selection.scss
@@ -2,21 +2,19 @@
   position: relative;
   display: inline-block;
   background-color: white;
-  border: 1px solid get-color('gray30');
   border-radius: 8px;
   cursor: pointer;
-  transition: border-color 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out;
 
   &:hover {
-    border-color: get-color('gray100');
+    background-color: get-color('gray20');
   }
 
   &--disabled {
-    border-color: get-color('gray40');
     background-color: get-color('gray40');
     cursor: not-allowed;
     &:hover {
-      border-color: get-color('gray40');
+      background-color: get-color('gray40');
     }
   }
 

--- a/ui-kit/src/sass/components/_Selection.scss
+++ b/ui-kit/src/sass/components/_Selection.scss
@@ -4,14 +4,49 @@
   background-color: white;
   border: 1px solid get-color('gray30');
   border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s ease-in-out;
 
-  .lubycon-selection--select {
+  &:hover {
+    border-color: get-color('gray100');
+  }
+
+  &--disabled {
+    border-color: get-color('gray40');
+    background-color: get-color('gray40');
+    cursor: not-allowed;
+    &:hover {
+      border-color: get-color('gray40');
+    }
+  }
+
+  &--empty select.lubycon-selection__select {
+    color: get-color('gray50');
+  }
+
+  &--size-small {
+    .lubycon-selection__select {
+      padding: 4px 32px 4px 16px;
+    }
+  }
+  &--size-medium {
+    .lubycon-selection__select {
+      padding: 8px 36px 8px 16px;
+    }
+  }
+  &--size-large {
+    .lubycon-selection__select {
+      padding: 12px 60px 12px 20px;
+    }
+  }
+
+  .lubycon-selection__select {
     width: 100%;
     background-color: transparent;
     appearance: none;
     outline: none;
     border: none;
-    padding: 8px 36px 8px 16px;
+    cursor: inherit;
   }
 
   .lubycon-icon {

--- a/ui-kit/src/sass/components/_index.scss
+++ b/ui-kit/src/sass/components/_index.scss
@@ -5,3 +5,5 @@
 @import './Column';
 @import './Checkbox';
 @import './Switch';
+@import './Selection';
+@import './Icon';

--- a/ui-kit/src/stories/Selection.stories.tsx
+++ b/ui-kit/src/stories/Selection.stories.tsx
@@ -21,7 +21,7 @@ export const Default = () => {
 export const Placeholder = () => {
   return (
     <div>
-      <Selection placeholder="선택해주세요">
+      <Selection placeholder="옵션을 선택하세요">
         <option>Option1</option>
         <option>Option2</option>
         <option>Option3</option>

--- a/ui-kit/src/stories/Selection.stories.tsx
+++ b/ui-kit/src/stories/Selection.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import Selection from 'components/Selection';
+
+export default {
+  title: 'Lubycon UI Kit/Selection',
+} as Meta;
+
+export const Default = () => {
+  return (
+    <div>
+      <Selection>
+        <option>Option1</option>
+        <option>Option2</option>
+        <option>Option3</option>
+      </Selection>
+    </div>
+  );
+};
+
+export const Placeholder = () => {
+  return (
+    <div>
+      <Selection placeholder="선택해주세요">
+        <option>Option1</option>
+        <option>Option2</option>
+        <option>Option3</option>
+      </Selection>
+    </div>
+  );
+};

--- a/ui-kit/src/stories/Selection.stories.tsx
+++ b/ui-kit/src/stories/Selection.stories.tsx
@@ -26,7 +26,7 @@ export const Sizes = () => {
   const selections = useMemo(() => {
     return ['small', 'medium', 'large'].map((size) => (
       <li key={size} style={{ marginBottom: 16, listStyle: ' none' }}>
-        <Selection placeholder={size} size={size as any}>
+        <Selection placeholder={size} size={size as ComponentProps<typeof Selection>['size']}>
           <option>옵션1</option>
           <option>옵션2</option>
           <option>옵션3</option>

--- a/ui-kit/src/stories/Selection.stories.tsx
+++ b/ui-kit/src/stories/Selection.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import Selection from 'components/Selection';
 import Text from 'components/Text';
@@ -26,7 +26,7 @@ export const Sizes = () => {
   const selections = useMemo(() => {
     return ['small', 'medium', 'large'].map((size) => (
       <li key={size} style={{ marginBottom: 16, listStyle: ' none' }}>
-        <Selection placeholder={size} size={size as ComponentProps<typeof Selection>['size']}>
+        <Selection placeholder={size} size={size as any}>
           <option>옵션1</option>
           <option>옵션2</option>
           <option>옵션3</option>

--- a/ui-kit/src/stories/Selection.stories.tsx
+++ b/ui-kit/src/stories/Selection.stories.tsx
@@ -1,18 +1,49 @@
-import React from 'react';
+import React, { ComponentProps, useMemo, useState } from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import Selection from 'components/Selection';
+import Text from 'components/Text';
 
 export default {
   title: 'Lubycon UI Kit/Selection',
 } as Meta;
 
 export const Default = () => {
+  const [state, setState] = useState('');
+
   return (
     <div>
-      <Selection>
-        <option>Option1</option>
-        <option>Option2</option>
-        <option>Option3</option>
+      <Selection onChange={(e) => setState(e.target.value)}>
+        <option>옵션1</option>
+        <option>옵션2</option>
+        <option>옵션3</option>
+      </Selection>
+      <Text style={{ display: 'block' }}>선택된 값은 {state}입니다.</Text>
+    </div>
+  );
+};
+
+export const Sizes = () => {
+  const selections = useMemo(() => {
+    return ['small', 'medium', 'large'].map((size) => (
+      <li key={size} style={{ marginBottom: 16, listStyle: ' none' }}>
+        <Selection placeholder={size} size={size as any}>
+          <option>옵션1</option>
+          <option>옵션2</option>
+          <option>옵션3</option>
+        </Selection>
+      </li>
+    ));
+  }, []);
+  return <ul>{selections}</ul>;
+};
+
+export const Disabled = () => {
+  return (
+    <div>
+      <Selection disabled>
+        <option>옵션1</option>
+        <option>옵션2</option>
+        <option>옵션3</option>
       </Selection>
     </div>
   );
@@ -21,10 +52,11 @@ export const Default = () => {
 export const Placeholder = () => {
   return (
     <div>
-      <Selection placeholder="옵션을 선택하세요">
-        <option>Option1</option>
-        <option>Option2</option>
-        <option>Option3</option>
+      <Selection placeholder="어느 곳에 사시나요?">
+        <option>서울</option>
+        <option>경기</option>
+        <option>인천</option>
+        <option>충남</option>
       </Selection>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9408,6 +9408,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+ionicons@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ionicons/-/ionicons-5.2.3.tgz#af4018ea7585b1e9ae11757731c77f2f36e0c7ac"
+  integrity sha512-87qtgBkieKVFagwYA9Cf91B3PCahQbEOMwMt8bSvlQSgflZ4eE5qI4MGj2ZlIyadeX0dgo+0CzZsy3ow0CsBAg==
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"


### PR DESCRIPTION
## 변경사항
<img width="1305" alt="스크린샷 2021-01-10 오전 12 22 32" src="https://user-images.githubusercontent.com/19145342/104095403-f82cd280-52d9-11eb-8047-a08002a9bd93.png">

Selection 컴포넌트를 추가합니다. Option 엘리먼트트의 UI는 디자인 챕터와 논의해서 일단은 네이티브 UI를 그대로 사용하기로 의사결정했습니다. 그래서 Select 태그 쪽만 스타일링 되어있음

- UI Kit 내 아이콘 사용을 위해 `ionicons` 라이브러리 추가
- `Icon` 컴포넌트 추가 (관련 대화: https://lubycon-hub.slack.com/archives/C01E919MTBM/p1609598708142600)

## 디자인 시안 링크
https://www.figma.com/file/e5zHg6E5rgkKw4v47EFXVe/Lubycon-UI-Library?node-id=0%3A1

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇‍♂️
