### PR TITLE
feat(ui-kit): 스낵바 컴포넌트 추가

### DIFF
--- a/ui-kit/src/components/LubyconUIKitProvider/index.tsx
+++ b/ui-kit/src/components/LubyconUIKitProvider/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { ToastProvider } from 'contexts/Toast';
 import { PortalProvider } from 'contexts/Portal';
+import { SnackbarProvider } from 'src/contexts/Snackbar';
 
 interface Props {
   children: ReactNode;
@@ -9,7 +10,9 @@ interface Props {
 function LubyconUIKitProvider({ children }: Props) {
   return (
     <PortalProvider>
-      <ToastProvider>{children}</ToastProvider>
+      <SnackbarProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </SnackbarProvider>
     </PortalProvider>
   );
 }

--- a/ui-kit/src/components/Snackbar/SnackbarBody.tsx
+++ b/ui-kit/src/components/Snackbar/SnackbarBody.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, isValidElement } from 'react';
 import classnames from 'classnames';
 import Text from 'components/Text';
-import {} from 'react';
 import Button from '../Button';
 
 interface Props {

--- a/ui-kit/src/components/Snackbar/SnackbarBody.tsx
+++ b/ui-kit/src/components/Snackbar/SnackbarBody.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode, isValidElement } from 'react';
+import classnames from 'classnames';
+import Text from 'components/Text';
+import {} from 'react';
+import Button from '../Button';
+
+interface Props {
+  message: string;
+  button: ReactNode;
+  onClick?: () => void;
+}
+
+const SnackbarBody = ({ message, button, onClick }: Props) => {
+  return (
+    <div className={classnames('lubycon-snackbar__body', 'lubycon-shadow--3')}>
+      <Text typography="p2" className="lubycon-snackbar__text">
+        {message}
+      </Text>
+      <div className="lubycon-snackbar__body__buttons">
+        {isValidElement(button) ? button : <Button onClick={onClick}>{button}</Button>}
+      </div>
+    </div>
+  );
+};
+
+export default SnackbarBody;

--- a/ui-kit/src/components/Snackbar/index.tsx
+++ b/ui-kit/src/components/Snackbar/index.tsx
@@ -2,15 +2,21 @@ import React, { HTMLAttributes, useEffect, useState, ReactNode } from 'react';
 import { animated, useTransition } from 'react-spring';
 import classnames from 'classnames';
 import SnackbarBody from './SnackbarBody';
+import { Combine } from 'src/types/utils';
 
-export interface SnackbarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
-  show: boolean;
-  message: string;
-  button: ReactNode;
-  autoHideDuration?: number;
-  onShow?: () => void;
-  onHide?: () => void;
-}
+export type SnackbarProps = Combine<
+  {
+    show: boolean;
+    message: string;
+    button: ReactNode;
+    autoHideDuration?: number;
+    onShow?: () => void;
+    onHide?: () => void;
+    onClick?: () => void;
+  },
+  HTMLAttributes<HTMLDivElement>
+>;
+
 const Snackbar = ({
   show,
   message,
@@ -18,6 +24,7 @@ const Snackbar = ({
   autoHideDuration,
   onShow,
   onHide,
+  onClick,
   className,
   style,
   ...rest
@@ -75,7 +82,7 @@ const Snackbar = ({
             }}
             {...rest}
           >
-            <SnackbarBody message={message} button={button} />
+            <SnackbarBody message={message} button={button} onClick={onClick} />
           </animated.div>
         ) : null;
       })}

--- a/ui-kit/src/components/Snackbar/index.tsx
+++ b/ui-kit/src/components/Snackbar/index.tsx
@@ -1,0 +1,86 @@
+import React, { HTMLAttributes, useEffect, useState, ReactNode } from 'react';
+import { animated, useTransition } from 'react-spring';
+import classnames from 'classnames';
+import SnackbarBody from './SnackbarBody';
+
+export interface SnackbarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  show: boolean;
+  message: string;
+  button: ReactNode;
+  autoHideDuration?: number;
+  onShow?: () => void;
+  onHide?: () => void;
+}
+const Snackbar = ({
+  show,
+  message,
+  button,
+  autoHideDuration,
+  onShow,
+  onHide,
+  className,
+  style,
+  ...rest
+}: SnackbarProps) => {
+  const [isOpen, setOpen] = useState(show);
+  const transition = useTransition(isOpen, null, {
+    from: {
+      opacity: 0,
+      transform: 'translateX(-100%)',
+      height: 60,
+    },
+    enter: [
+      { height: 60 },
+      {
+        opacity: 1,
+        transform: 'translateX(0)',
+      },
+    ],
+    leave: [
+      {
+        opacity: 0,
+        transform: 'translateX(-100%)',
+      },
+      { height: 0 },
+    ],
+    onStart: () => {
+      onShow?.();
+    },
+    onDestroyed: () => {
+      onHide?.();
+    },
+  });
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (autoHideDuration != null && isOpen === true) {
+      timer = setTimeout(() => {
+        setOpen(false);
+      }, autoHideDuration);
+    }
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      {transition.map(({ item, key, props }) => {
+        return item ? (
+          <animated.div
+            key={key}
+            className={classnames('lubycon-snackbar', className)}
+            style={{
+              ...style,
+              ...props,
+            }}
+            {...rest}
+          >
+            <SnackbarBody message={message} button={button} />
+          </animated.div>
+        ) : null;
+      })}
+    </>
+  );
+};
+
+export default Snackbar;

--- a/ui-kit/src/components/Snackbar/index.tsx
+++ b/ui-kit/src/components/Snackbar/index.tsx
@@ -14,7 +14,7 @@ export type SnackbarProps = Combine<
     onHide?: () => void;
     onClick?: () => void;
   },
-  HTMLAttributes<HTMLDivElement>
+  Omit<HTMLAttributes<HTMLDivElement>, 'children'>
 >;
 
 const Snackbar = ({

--- a/ui-kit/src/components/index.ts
+++ b/ui-kit/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as LubyconUIKitProvider } from './LubyconUIKitProvider';
 export { default as Toast } from './Toast';
 export { default as Tooltip } from './Tooltip';
 export { Tabs, TabPane } from './Tabs';
+export { default as Snackbar } from './Snackbar';

--- a/ui-kit/src/contexts/Snackbar.tsx
+++ b/ui-kit/src/contexts/Snackbar.tsx
@@ -1,0 +1,79 @@
+import React, { ReactNode, createContext, useState, useCallback, useContext } from 'react';
+import classnames from 'classnames';
+import Snackbar, { SnackbarProps } from 'components/Snackbar';
+import { generateID } from 'src/utils';
+import { Portal } from './Portal';
+interface SnackbarOptions extends Omit<SnackbarProps, 'show'> {
+  duration?: number;
+}
+
+interface SnackbarGlobalState {
+  openSnackbar: (option: SnackbarOptions) => void;
+  closeSnackbar: (toastId: string) => void;
+}
+const SnackbarContext = createContext<SnackbarGlobalState>({
+  openSnackbar: () => {},
+  closeSnackbar: () => {},
+});
+
+interface SnackbarProviderProps {
+  children: ReactNode;
+  maxStack?: number;
+}
+export function SnackbarProvider({ children, maxStack = 1 }: SnackbarProviderProps) {
+  const [openedSnackbarQueue, setOpenedSnackbarQueue] = useState<SnackbarOptions[]>([]);
+
+  const openSnackbar = useCallback(
+    ({ id = generateID('lubycon-snackbar'), ...option }: SnackbarOptions) => {
+      const snackbar = { id, ...option };
+      const [, ...rest] = openedSnackbarQueue;
+
+      if (openedSnackbarQueue.length >= maxStack) {
+        setOpenedSnackbarQueue([...rest, snackbar]);
+      } else {
+        setOpenedSnackbarQueue([...openedSnackbarQueue, snackbar]);
+      }
+    },
+    [openedSnackbarQueue]
+  );
+
+  const closeSnackbar = useCallback(
+    (closedSnackbarId: string) => {
+      setOpenedSnackbarQueue(
+        openedSnackbarQueue.filter((snackbar) => snackbar.id !== closedSnackbarId)
+      );
+    },
+    [openedSnackbarQueue]
+  );
+
+  return (
+    <SnackbarContext.Provider
+      value={{
+        openSnackbar,
+        closeSnackbar,
+      }}
+    >
+      {children}
+      <Portal>
+        <div className={classnames('lubycon-snackbar__context-container')}>
+          {openedSnackbarQueue.map(({ id, onHide, duration = 3000, ...snackbarProps }) => (
+            <Snackbar
+              key={id}
+              show={true}
+              autoHideDuration={duration}
+              onHide={() => {
+                closeSnackbar(id ?? '');
+                onHide?.();
+              }}
+              {...snackbarProps}
+            />
+          ))}
+        </div>
+      </Portal>
+    </SnackbarContext.Provider>
+  );
+}
+
+export function useSnackbar() {
+  return useContext(SnackbarContext);
+}

--- a/ui-kit/src/sass/components/_Button.scss
+++ b/ui-kit/src/sass/components/_Button.scss
@@ -12,15 +12,12 @@
   transition: background-color 0.2s ease-in-out;
 
   &__small {
-    height: 32px;
     padding: 4px 16px;
   }
   &__medium {
-    height: 40px;
     padding: 8px 16px;
   }
   &__large {
-    height: 56px;
     padding: 12px 32px;
     border-radius: 8px;
   }

--- a/ui-kit/src/sass/components/_Snackbar.scss
+++ b/ui-kit/src/sass/components/_Snackbar.scss
@@ -6,7 +6,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 8px 16px;
-    min-width: 336px;
+    min-width: 400px;
     border-radius: 4px;
     background-color: white;
     margin: 12px 0;
@@ -17,7 +17,7 @@
   }
 
   .lubycon-snackbar__body__buttons {
-    margin-left: 6px;
+    margin-left: 16px;
   }
 
   &:first-of-type {

--- a/ui-kit/src/sass/components/_Snackbar.scss
+++ b/ui-kit/src/sass/components/_Snackbar.scss
@@ -18,6 +18,9 @@
 
   .lubycon-snackbar__body__buttons {
     margin-left: 16px;
+    .lubycon-button + .lubycon-button {
+      margin-left: 8px;
+    }
   }
 
   &:first-of-type {

--- a/ui-kit/src/sass/components/_Snackbar.scss
+++ b/ui-kit/src/sass/components/_Snackbar.scss
@@ -1,0 +1,38 @@
+.lubycon-snackbar {
+  overflow: visible;
+
+  .lubycon-snackbar__body {
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 16px;
+    min-width: 336px;
+    border-radius: 4px;
+    background-color: white;
+    margin: 12px 0;
+  }
+
+  .lubycon-snackbar__text {
+    white-space: pre;
+  }
+
+  .lubycon-snackbar__body__buttons {
+    margin-left: 6px;
+  }
+
+  &:first-of-type {
+    .lubycon-snackbar__body {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.lubycon-snackbar__context-container {
+  position: fixed;
+  display: flex;
+  flex-direction: column-reverse;
+  top: auto;
+  bottom: 40px;
+  left: 40px;
+  right: auto;
+}

--- a/ui-kit/src/sass/components/_index.scss
+++ b/ui-kit/src/sass/components/_index.scss
@@ -10,3 +10,4 @@
 @import './Toast';
 @import './Tooltip';
 @import './Tabs';
+@import './Snackbar';

--- a/ui-kit/src/stories/Snackbar.stories.tsx
+++ b/ui-kit/src/stories/Snackbar.stories.tsx
@@ -3,7 +3,6 @@ import { Meta } from '@storybook/react/types-6-0';
 import Snackbar from 'components/Snackbar';
 import Button from 'components/Button';
 import { useSnackbar } from 'contexts/Snackbar';
-import { generateID } from 'src/utils';
 
 export default {
   title: 'Lubycon UI Kit/Snackbar',
@@ -16,7 +15,7 @@ export const Default = () => {
       <Snackbar show={true} message="데이터 전송이 완료되었습니다." button="실행취소" />
       <Snackbar
         show={true}
-        message={`사용하시는 단말기의 네트워크 상태가 좋지 않습니다.\nWIFI 혹은 3G/LTE 연결 상태를 확인해주세요.`}
+        message={`16개의 이미지가\n“동물" 폴더에 추가되었습니다.`}
         button="실행취소"
       />
     </div>
@@ -32,7 +31,7 @@ export const AutoHide = () => {
         show={show}
         autoHideDuration={3000}
         onHide={() => setShow(true)}
-        message={`사용하시는 단말기의 네트워크 상태가 좋지 않습니다.\nWIFI 혹은 3G/LTE 연결 상태를 확인해주세요.`}
+        message={`16개의 이미지가\n“동물" 폴더에 추가되었습니다.`}
         button="실행취소"
       />
     </div>
@@ -46,8 +45,50 @@ export const SnackbarHooks = () => {
       <Button
         onClick={() =>
           openSnackbar({
-            message: `데이터 전송이 완료되었습니다 - ${generateID('snackbar-test')}`,
+            message: `파일이 휴지통으로 이동되었습니다.`,
             button: '실행취소',
+          })
+        }
+      >
+        스낵바 열기
+      </Button>
+    </div>
+  );
+};
+
+export const onClick = () => {
+  const { openSnackbar } = useSnackbar();
+  return (
+    <div>
+      <Button
+        onClick={() =>
+          openSnackbar({
+            message: `파일이 휴지통으로 이동되었습니다.`,
+            button: '실행취소',
+            onClick: () => alert('실행 취소 완료'),
+          })
+        }
+      >
+        스낵바 열기
+      </Button>
+    </div>
+  );
+};
+
+export const multipleButton = () => {
+  const { openSnackbar } = useSnackbar();
+  return (
+    <div>
+      <Button
+        onClick={() =>
+          openSnackbar({
+            message: `메세지가 전송되었습니다.`,
+            button: (
+              <>
+                <Button onClick={() => alert('실행 취소 완료')}>실행취소</Button>
+                <Button onClick={() => alert('메세지 보기 클릭')}>메세지 보기</Button>
+              </>
+            ),
           })
         }
       >

--- a/ui-kit/src/stories/Snackbar.stories.tsx
+++ b/ui-kit/src/stories/Snackbar.stories.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import Snackbar from 'components/Snackbar';
+import Button from 'components/Button';
+import { useSnackbar } from 'contexts/Snackbar';
+import { generateID } from 'src/utils';
+
+export default {
+  title: 'Lubycon UI Kit/Snackbar',
+  component: Snackbar,
+} as Meta;
+
+export const Default = () => {
+  return (
+    <div>
+      <Snackbar show={true} message="데이터 전송이 완료되었습니다." button="실행취소" />
+      <Snackbar
+        show={true}
+        message={`사용하시는 단말기의 네트워크 상태가 좋지 않습니다.\nWIFI 혹은 3G/LTE 연결 상태를 확인해주세요.`}
+        button="실행취소"
+      />
+    </div>
+  );
+};
+
+export const AutoHide = () => {
+  const [show, setShow] = useState(true);
+  return (
+    <div>
+      <Snackbar show={true} message="데이터 전송이 완료되었습니다." button="실행취소" />
+      <Snackbar
+        show={show}
+        autoHideDuration={3000}
+        onHide={() => setShow(true)}
+        message={`사용하시는 단말기의 네트워크 상태가 좋지 않습니다.\nWIFI 혹은 3G/LTE 연결 상태를 확인해주세요.`}
+        button="실행취소"
+      />
+    </div>
+  );
+};
+
+export const SnackbarHooks = () => {
+  const { openSnackbar } = useSnackbar();
+  return (
+    <div>
+      <Button
+        onClick={() =>
+          openSnackbar({
+            message: `데이터 전송이 완료되었습니다 - ${generateID('snackbar-test')}`,
+            button: '실행취소',
+          })
+        }
+      >
+        스낵바 열기
+      </Button>
+    </div>
+  );
+};

--- a/ui-kit/src/stories/Snackbar.stories.tsx
+++ b/ui-kit/src/stories/Snackbar.stories.tsx
@@ -82,7 +82,7 @@ export const multipleButton = () => {
       <Button
         onClick={() =>
           openSnackbar({
-            message: `메세지가 전송되었습니다.`,
+            message: '메세지가 전송되었습니다.',
             button: (
               <>
                 <Button onClick={() => alert('실행 취소 완료')}>실행취소</Button>

--- a/ui-kit/src/stories/Toast.stories.tsx
+++ b/ui-kit/src/stories/Toast.stories.tsx
@@ -3,7 +3,6 @@ import { Meta } from '@storybook/react/types-6-0';
 import Toast from 'components/Toast';
 import Button from 'components/Button';
 import { useToast } from 'contexts/Toast';
-import { generateID } from 'src/utils';
 
 export default {
   title: 'Lubycon UI Kit/Toast',
@@ -44,7 +43,7 @@ export const ToastHooks = () => {
       <Button
         onClick={() =>
           openToast({
-            message: `데이터 전송이 완료되었습니다 - ${generateID('toast-test')}`,
+            message: `데이터 전송이 완료되었습니다`,
           })
         }
       >


### PR DESCRIPTION
## 변경사항

<img width="615" alt="스크린샷 2021-02-06 오후 5 06 12" src="https://user-images.githubusercontent.com/19145342/107112870-33510000-689e-11eb-846f-79dd042c4a2e.png">

<img width="498" alt="스크린샷 2021-02-06 오후 5 07 19" src="https://user-images.githubusercontent.com/19145342/107112872-364bf080-689e-11eb-8a46-a309cff6cd87.png">

대부분 토스트 컴포넌트의 복붙입니다. 추상화는 TO DO로 가져가겠슴다.

- `Snackbar` 컴포넌트 추가
- `SnackbarContext` 추가
- `Button` 컴포넌트의 `height` 속성 제거 (`line-height` 가 안 맞아서 버튼이 비뚤게 보임. 디챕과 협의해야함)

### Declarative

```jsx
<Snackbar show={true} message="하이호이 테스트입니다" button="실행취소" onClick={() => {}} />
<Snackbar
  show={true}
  message="하이호이 테스트입니다"
  button={
    <>
      <Button onClick={() => alert('실행 취소 완료')}>실행취소</Button>
      <Button onClick={() => alert('메세지 보기 클릭')}>메세지 보기</Button>
    </>
  }
/>
```

싱글 버튼과 멀티버튼은 이런 식으로 사용할 수 있습니다. `button` 프로퍼티에 원시형 타입가 아닌 타입이 들어올 경우 `onClick: never`로 정의하려고 했는데, 요것도 일단 TO DO로....ㅎㅎ 도전해보고 싶으신 분 있으시면 해보시면 좋을 것 같습니다.

### imperative

```ts
const { openSnackbar } = useSnackbar();
openSnackbar({
  message: '하이호이 테스트입니다',
  button: '실행취소',
  onClick: handleSnackbarClick
});
```

## 디자인 시안 링크
https://www.figma.com/file/e5zHg6E5rgkKw4v47EFXVe/Lubycon-UI-Library?node-id=0%3A1

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇‍♂️
