### PR TITLE
feat(ui-kit): Input 컴포넌트 추가

### DIFF
--- a/ui-kit/src/components/Input/index.tsx
+++ b/ui-kit/src/components/Input/index.tsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import { Combine } from 'src/types/utils';
 import Text from '../Text';
 
-type TextInputType = 'text' | 'tel' | 'url' | 'email' | 'number' | 'password' | 'search';
+export type TextInputType = 'text' | 'tel' | 'url' | 'email' | 'number' | 'password' | 'search';
 type Props = Combine<
   {
     label?: ReactNode;

--- a/ui-kit/src/components/Input/index.tsx
+++ b/ui-kit/src/components/Input/index.tsx
@@ -1,0 +1,103 @@
+import React, {
+  forwardRef,
+  InputHTMLAttributes,
+  isValidElement,
+  ReactNode,
+  useMemo,
+  useState,
+} from 'react';
+import classnames from 'classnames';
+import { Combine } from 'src/types/utils';
+import Text from '../Text';
+
+type TextInputType = 'text' | 'tel' | 'url' | 'email' | 'number' | 'password' | 'search';
+type Props = Combine<
+  {
+    label?: ReactNode;
+    type?: TextInputType;
+    right?: ReactNode;
+    hasError?: boolean;
+    description?: string;
+  },
+  InputHTMLAttributes<HTMLInputElement>
+>;
+const Input = forwardRef<HTMLInputElement, Props>(function Input(
+  {
+    style,
+    label,
+    className,
+    disabled,
+    type = 'text',
+    right,
+    hasError,
+    description,
+    onFocus,
+    onBlur,
+    ...props
+  },
+  ref
+) {
+  const [isFocused, setFocus] = useState(false);
+  const hasLabel = label != null;
+  const hasDescription = description != null;
+  const hasRightArea = right != null;
+
+  const labelElement = useMemo(() => {
+    if (hasLabel) {
+      return (
+        <span className="lubycon-input__label">
+          {isValidElement(label) ? label : <Text>{label}</Text>}
+        </span>
+      );
+    }
+    return null;
+  }, [label]);
+
+  return (
+    <label
+      className={classnames(
+        'lubycon-input',
+        {
+          'lubycon-input--disabled': disabled,
+          'lubycon-input--focused': isFocused,
+          'lubycon-input--with-label': hasLabel,
+          'lubycon-input--with-description': hasDescription,
+          'lubycon-input--has-error': hasError,
+        },
+        className
+      )}
+      style={style}
+    >
+      {labelElement}
+      <div
+        className={classnames('lubycon-input__form', {
+          'lubycon-input__form--with-right-area': hasRightArea,
+        })}
+      >
+        <input
+          ref={ref}
+          className={classnames('lubycon-input__form__input-element', 'lubycon-typography-p1')}
+          type={type}
+          disabled={disabled}
+          onFocus={(e) => {
+            setFocus(true);
+            onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setFocus(false);
+            onBlur?.(e);
+          }}
+          {...props}
+        />
+        {right != null ? <span className="lubycon-input__form__right">{right}</span> : null}
+      </div>
+      {description ? (
+        <Text className="lubycon-input__description" typography="caption">
+          {description}
+        </Text>
+      ) : null}
+    </label>
+  );
+});
+
+export default Input;

--- a/ui-kit/src/index.ts
+++ b/ui-kit/src/index.ts
@@ -19,6 +19,7 @@ export {
   CardFooter,
 } from './components/Card';
 export { default as Snackbar } from './components/Snackbar';
+export { default as Input } from './components/Input';
 export { Portal } from './contexts/Portal';
 export { useToast } from './contexts/Toast';
 export { useSnackbar } from './contexts/Snackbar';

--- a/ui-kit/src/sass/components/_Input.scss
+++ b/ui-kit/src/sass/components/_Input.scss
@@ -1,0 +1,80 @@
+$label-position: 34px;
+$description-position: 30px;
+
+.lubycon-input {
+  position: relative;
+  display: inline-block;
+  background-color: get-color('gray20');
+  padding: 10px;
+  border-radius: 8px;
+  border: 2px solid transparent;
+  transition: border 0.1s ease-in-out, background-color 0.1s ease-in-out;
+  box-sizing: border-box;
+
+  &--disabled {
+    background-color: get-color('gray30');
+    .lubycon-input__form__input-element {
+      cursor: not-allowed;
+      &::placeholder {
+        color: get-color('gray60');
+      }
+    }
+    .lubycon-input__label {
+      color: get-color('gray60');
+    }
+  }
+
+  &--focused {
+    border-color: get-color('gray50');
+    background-color: get-color('gray10');
+  }
+
+  &--with-label {
+    margin-top: $label-position;
+  }
+  &--with-description {
+    margin-bottom: $description-position;
+  }
+  &--has-error {
+    border-color: get-color('red50');
+    .lubycon-input__label {
+      color: get-color('red50');
+    }
+    .lubycon-input__description {
+      color: get-color('red50');
+    }
+  }
+
+  &__label {
+    position: absolute;
+    left: 0;
+    top: -$label-position;
+    transition: color 0.1s ease-in-out;
+  }
+
+  &__form {
+    display: flex;
+    align-items: center;
+    &__input-element {
+      flex-grow: 1;
+      background-color: transparent;
+      border: none;
+      outline: none;
+      line-height: 16px;
+      margin-top: 3px;
+      &::placeholder {
+        color: get-color('gray70');
+      }
+    }
+    &__right {
+      display: inline-flex;
+    }
+  }
+
+  &__description {
+    position: absolute;
+    left: 0;
+    bottom: -$description-position;
+    color: get-color('gray70');
+  }
+}

--- a/ui-kit/src/sass/components/_index.scss
+++ b/ui-kit/src/sass/components/_index.scss
@@ -14,3 +14,4 @@
 @import './Card';
 @import './Snackbar';
 @import './Container';
+@import './Input';

--- a/ui-kit/src/stories/Input.stories.tsx
+++ b/ui-kit/src/stories/Input.stories.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Input, Text, colors } from 'src';
+import { Meta } from '@storybook/react/types-6-0';
+import Icon from 'src/components/Icon';
+import { checkmarkCircle } from 'ionicons/icons';
+
+export default {
+  title: 'Lubycon UI Kit/Input',
+} as Meta;
+
+export const Default = () => {
+  const [state, setState] = useState('');
+  return (
+    <div>
+      <Text style={{ marginBottom: 16, display: 'block' }}>입력된 값: {state}</Text>
+      <Input value={state} onChange={(e) => setState(e.target.value)} />
+    </div>
+  );
+};
+
+export const Label = () => {
+  const [value, setValue] = useState('');
+  return (
+    <div>
+      <Text style={{ marginBottom: 16, display: 'block' }}>입력된 값: {value}</Text>
+      <Input label="라벨이에요" value={value} onChange={(e) => setValue(e.target.value)} />
+    </div>
+  );
+};
+
+export const Placeholder = () => {
+  return <Input label="라벨이에요" placeholder="텍스트를 입력하세요" />;
+};
+
+export const Disabled = () => {
+  return <Input label="라벨이에요" placeholder="텍스트를 입력하세요" disabled={true} />;
+};
+
+export const Error = () => {
+  const [value, setValue] = useState('');
+  const isError = value === '';
+
+  return (
+    <Input
+      style={{ width: 300 }}
+      label="라벨이에요"
+      placeholder="텍스트를 입력하세요"
+      hasError={isError}
+      description={isError ? '빈 문자열은 허용되지 않습니다' : undefined}
+      onChange={(e) => setValue(e.target.value)}
+      right={
+        isError ? null : (
+          <Icon icon={checkmarkCircle} type="filled" color={colors.green50} size={20} />
+        )
+      }
+    />
+  );
+};

--- a/ui-kit/src/stories/Input.stories.tsx
+++ b/ui-kit/src/stories/Input.stories.tsx
@@ -3,6 +3,7 @@ import { Input, Text, colors } from 'src';
 import { Meta } from '@storybook/react/types-6-0';
 import Icon from 'src/components/Icon';
 import { checkmarkCircle } from 'ionicons/icons';
+import { TextInputType } from 'components/Input';
 
 export default {
   title: 'Lubycon UI Kit/Input',
@@ -52,5 +53,25 @@ export const Error = () => {
         )
       }
     />
+  );
+};
+
+const types: TextInputType[] = ['text', 'email', 'number', 'password', 'search', 'tel', 'url'];
+const covertToTitlecase = (s: string) => `${s.charAt(0).toUpperCase()}${s.slice(1, s.length)}`;
+export const Types = () => {
+  return (
+    <div>
+      <Text>
+        모바일에서는 인풋의 타입에 따라 다른 키보드가 노출되니, 모바일 환경에서 확인해보시는 것을
+        추천합니다.
+      </Text>
+      <ul>
+        {types.map((type) => (
+          <li key={type}>
+            <Input label={covertToTitlecase(type)} type={type} />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 };

--- a/ui-kit/src/stories/Input.stories.tsx
+++ b/ui-kit/src/stories/Input.stories.tsx
@@ -19,11 +19,9 @@ export const Default = () => {
 };
 
 export const Label = () => {
-  const [value, setValue] = useState('');
   return (
     <div>
-      <Text style={{ marginBottom: 16, display: 'block' }}>입력된 값: {value}</Text>
-      <Input label="라벨이에요" value={value} onChange={(e) => setValue(e.target.value)} />
+      <Input label="라벨이에요" />
     </div>
   );
 };


### PR DESCRIPTION
## 변경사항

<img width="1094" alt="스크린샷 2021-02-16 오전 12 45 48" src="https://user-images.githubusercontent.com/19145342/107967456-79216d00-6ff0-11eb-958a-437d6d6dacde.png">

`Input` 컴포넌트를 추가합니다. 기본적으로 `input` 엘리먼트의 인터페이스를 확장하되, `type`을 텍스트 입력과 관련된 타입만 받을 수 있도록 제한합니다.

### Available Types

```ts
type TextInputType = 'text' | 'tel' | 'url' | 'email' | 'number' | 'password' | 'search';
```

### Interface

```tsx
<Input
  style={{ width: 300 }}
  label="라벨이에요"
  placeholder="텍스트를 입력하세요"
  hasError={isError}
  description={isError ? '빈 문자열은 허용되지 않습니다' : undefined}
  onChange={(e) => setValue(e.target.value)}
  right={
    isError ? null : (
      <Icon icon={checkmarkCircle} type="filled" color={colors.green50} size={20} />
    )
  }
/>
```

## 디자인 시안 링크
https://www.figma.com/file/e5zHg6E5rgkKw4v47EFXVe/Lubycon-UI-Library?node-id=0%3A1

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇‍♂️