### PR TITLE
feat(ui-kit): Modal 컴포넌트 애니메이션 추가

### DIFF
--- a/ui-kit/src/components/Modal/index.tsx
+++ b/ui-kit/src/components/Modal/index.tsx
@@ -54,9 +54,7 @@ const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) 
   }, []);
 
   useEffect(() => {
-    if (show === true) {
-      setShowModal(true);
-    }
+    setShowModal(show);
   }, [show]);
 
   return (

--- a/ui-kit/src/components/Modal/index.tsx
+++ b/ui-kit/src/components/Modal/index.tsx
@@ -3,6 +3,7 @@ import ModalBackdrop from './ModalBackdrop';
 import ModalWindow from './ModalWindow';
 import { generateID } from 'utils/index';
 import { animated, useTransition } from 'react-spring';
+import { useState } from 'react';
 
 export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   show: boolean;
@@ -13,16 +14,19 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) => {
+  const [showModal, setShowModal] = useState(show);
   const backdropRef = useRef(null);
-  const backdropTransition = useTransition(show, null, {
+  const backdropTransition = useTransition(showModal, null, {
     from: { opacity: 0 },
     enter: { opacity: 1 },
     leave: { opacity: 0 },
   });
-  const modalTransition = useTransition(show, null, {
+  const modalTransition = useTransition(showModal, null, {
     from: { transform: 'translate(-50%, 100%)', opacity: 0 },
     enter: { transform: 'translate(-50%, -50%)', opacity: 1 },
     leave: { transform: 'translate(-50%, 100%)', opacity: 0 },
+    onStart: () => onOpen?.(),
+    onDestroyed: () => onClose?.(),
   });
 
   const handleBackdropClick = useCallback(
@@ -30,7 +34,7 @@ const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) 
       if (backdropRef.current == null) {
         return;
       } else if (event.target === backdropRef.current) {
-        onClose?.();
+        setShowModal(false);
       }
     },
     [onClose]
@@ -38,7 +42,7 @@ const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) 
 
   const onKeydown = (event: KeyboardEvent) => {
     if (event.key === 'Escape') {
-      onClose?.();
+      setShowModal(false);
     }
   };
 
@@ -51,7 +55,7 @@ const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) 
 
   useEffect(() => {
     if (show === true) {
-      onOpen?.();
+      setShowModal(true);
     }
   }, [show]);
 

--- a/ui-kit/src/components/Table/TableCell.tsx
+++ b/ui-kit/src/components/Table/TableCell.tsx
@@ -13,7 +13,7 @@ const TableCell = ({ children, align = 'left', as }: TableCellProps) => {
   const Component = as ?? isHeadCell;
 
   return (
-    <Component className={classnames("lubycon-table__cell", `lubycon-table--align-${align}`)}>
+    <Component className={classnames('lubycon-table__cell', `lubycon-table--align-${align}`)}>
       {children}
     </Component>
   );

--- a/ui-kit/src/components/Table/TableHead.tsx
+++ b/ui-kit/src/components/Table/TableHead.tsx
@@ -7,9 +7,7 @@ const TableHeadContext = createContext({ variant: '' });
 const TableHead = ({ children }: TableProps) => {
   return (
     <TableHeadContext.Provider value={{ variant: 'head' }}>
-      <thead className="lubycon-table__head">
-        {children}
-      </thead>
+      <thead className="lubycon-table__head">{children}</thead>
     </TableHeadContext.Provider>
   );
 };

--- a/ui-kit/src/components/Table/TableRow.tsx
+++ b/ui-kit/src/components/Table/TableRow.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import classnames from 'classnames';
 import { TableProps } from './index';
 
 const TableRow = ({ children }: TableProps) => {
-  return <tr className={classnames('lubycon-table__row')}>{children}</tr>;
+  return <tr className="lubycon-table__row">{children}</tr>;
 };
 
 export default TableRow;

--- a/ui-kit/src/components/Table/TableRow.tsx
+++ b/ui-kit/src/components/Table/TableRow.tsx
@@ -3,11 +3,7 @@ import classnames from 'classnames';
 import { TableProps } from './index';
 
 const TableRow = ({ children }: TableProps) => {
-  return (
-    <tr className={classnames('lubycon-table__row')}>
-      {children}
-    </tr>
-  );
+  return <tr className={classnames('lubycon-table__row')}>{children}</tr>;
 };
 
 export default TableRow;

--- a/ui-kit/src/contexts/Modal.tsx
+++ b/ui-kit/src/contexts/Modal.tsx
@@ -40,7 +40,7 @@ export function ModalProvider({ children }: ModalProviderProps) {
   const closeModal = useCallback((closedModalId: string) => {
     setOpenedModalStack((stack) =>
       stack.map((modal) => {
-        return modal.id == closedModalId
+        return modal.id === closedModalId
           ? {
               ...modal,
               show: false,

--- a/ui-kit/src/contexts/Modal.tsx
+++ b/ui-kit/src/contexts/Modal.tsx
@@ -1,10 +1,12 @@
 import React, { useContext, ReactNode, createContext, useState, useCallback } from 'react';
-import Modal, { ModalProps } from 'components/Modal';
+import Modal, { ModalContent, ModalFooter, ModalHeader, ModalProps } from 'components/Modal';
 import { generateID } from 'src/utils';
 import { Portal } from './Portal';
 
-interface ModalOptions extends Omit<ModalProps, 'show'> {
-  test?: boolean;
+interface ModalOptions extends Omit<ModalProps, 'show' | 'children' | 'title'> {
+  title?: ReactNode;
+  contents?: ReactNode;
+  footer?: ReactNode;
 }
 interface ModalGlobalState {
   openModal: (option: ModalOptions) => void;
@@ -24,11 +26,12 @@ export function ModalProvider({ children }: ModalProviderProps) {
 
   const openModal = useCallback(
     ({ id = generateID('lubycon-modal'), ...option }: ModalOptions) => {
-      const modal = { id, ...option };
+      const modal = { id, show: true, ...option };
       setOpenedModalStack([...openedModalStack, modal]);
     },
     [openedModalStack]
   );
+
   const closeModal = useCallback(
     (closedModalId: string) => {
       setOpenedModalStack(openedModalStack.filter((modal) => modal.id !== closedModalId));
@@ -45,8 +48,12 @@ export function ModalProvider({ children }: ModalProviderProps) {
     >
       {children}
       <Portal>
-        {openedModalStack.map(({ id, ...modalProps }) => (
-          <Modal show={true} key={id} onClose={() => closeModal(id ?? '')} {...modalProps} />
+        {openedModalStack.map(({ id, title, contents, footer, ...modalProps }) => (
+          <Modal show={true} key={id} onClose={() => closeModal(id ?? '')} {...modalProps}>
+            <ModalHeader>{title}</ModalHeader>
+            <ModalContent>{contents}</ModalContent>
+            <ModalFooter>{footer}</ModalFooter>
+          </Modal>
         ))}
       </Portal>
     </ModalContext.Provider>

--- a/ui-kit/src/contexts/Modal.tsx
+++ b/ui-kit/src/contexts/Modal.tsx
@@ -26,7 +26,7 @@ export function ModalProvider({ children }: ModalProviderProps) {
 
   const openModal = useCallback(
     ({ id = generateID('lubycon-modal'), ...option }: ModalOptions) => {
-      const modal = { id, show: true, ...option };
+      const modal = { id, ...option };
       setOpenedModalStack([...openedModalStack, modal]);
     },
     [openedModalStack]

--- a/ui-kit/src/sass/components/_Modal.scss
+++ b/ui-kit/src/sass/components/_Modal.scss
@@ -1,25 +1,24 @@
 .lubycon-modal {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  overflow: auto;
-  z-index: 1000;
-
   &__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     background-color: get-color('gray100');
     opacity: 0.5;
+    z-index: 1000;
+  }
+  &__window-wrapper {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    z-index: 1001;
   }
   &__window {
     background-color: get-color('gray10');
     border-radius: 4px;
     box-sizing: border-box;
-    z-index: 1001;
     &--small {
       width: 280px;
       padding: 16px 20px;

--- a/ui-kit/src/stories/Modal.stories.tsx
+++ b/ui-kit/src/stories/Modal.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Modal, ModalHeader, ModalContent, ModalFooter } from 'src';
 import Button from 'components/Button';
 import { colors } from 'constants/colors';
+import { useModal } from 'src/contexts/Modal';
 
 export default {
   title: 'Lubycon UI kit/Modal',
@@ -39,4 +40,35 @@ export const Default = () => {
       </Modal>
     </>
   );
+};
+
+export const ModalHooks = () => {
+  const { openModal, closeModal } = useModal();
+  const handleClick = () => {
+    openModal({
+      title: '타이틀입니다',
+      contents: (
+        <>
+          <div>여기에 본문 텍스트가 들어갑니다</div>
+          <div>여기에 본문 텍스트가 들어갑니다</div>
+        </>
+      ),
+      footer: (
+        <>
+          <Button
+            size="small"
+            style={{ color: colors.gray80, background: 'transparent', marginRight: '4px' }}
+            onClick={() => closeModal}
+          >
+            취소
+          </Button>
+          <Button size="small" onClick={() => closeModal}>
+            저장하기
+          </Button>
+        </>
+      ),
+    });
+  };
+
+  return <Button onClick={handleClick}>모달 열기</Button>;
 };

--- a/ui-kit/src/stories/Table.stories.tsx
+++ b/ui-kit/src/stories/Table.stories.tsx
@@ -21,7 +21,7 @@ export const Default = () => {
         </TableRow>
       </TableHead>
       <TableBody>
-        {iterator.map((v, rowIdx) => (
+        {iterator.map((_, rowIdx) => (
           <TableRow key={`tbody-row-${rowIdx}`}>
             {contents.map((content, contentIdx) => (
               <TableCell key={`td-${contentIdx}`}>{content}</TableCell>


### PR DESCRIPTION
## 변경사항
`Modal` 컴포넌트에 애니메이션을 추가합니다.

## 디자인 시안 링크
https://www.figma.com/file/e5zHg6E5rgkKw4v47EFXVe/Lubycon-UI-Library?node-id=0%3A1

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
~~`useModal`의 `closeModal` 사용 시 모달 스택 배열에서 바로 모달 상태가 제거되면서 애니메이션이 실행되지 않고 바로 모달이 사라지는 이슈가 있습니다. 애니메이션 끝난 다음에 스택 배열에서 모달 상태를 제거해야하는데, 일단 아이디어가 안 떠올라서 그냥 고고 했습니당~~

요거 해결했슴당 ㅎㅎ
