### PR TITLE
Feat/text mobile

### DIFF
--- a/ui-kit/package.json
+++ b/ui-kit/package.json
@@ -22,7 +22,6 @@
   "author": "Lubycon",
   "dependencies": {
     "classnames": "^2.2.6",
-    "ionicons": "^5.2.3",
     "react-spring": "^8.0.27",
     "resize-observer-polyfill": "^1.5.1"
   },

--- a/ui-kit/src/components/Accordion/index.tsx
+++ b/ui-kit/src/components/Accordion/index.tsx
@@ -60,7 +60,7 @@ const Accordion = forwardRef<HTMLDivElement, Props>(function Accordion(
     >
       <div className="lubycon-accordion__label" onClick={toggleContentOpen} role="button">
         <Icon
-          icon={chevronDown}
+          name="chevron-down"
           type="outline"
           size={20}
           className="lubycon-accordion__label__icon"

--- a/ui-kit/src/components/Alert/index.tsx
+++ b/ui-kit/src/components/Alert/index.tsx
@@ -3,7 +3,6 @@ import { colors, SemanticColor } from 'src/constants/colors';
 import classnames from 'classnames';
 import Text from '../Text';
 import Icon from '../Icon';
-import { informationCircle, closeCircle, alertCircle, checkmarkCircle } from 'ionicons/icons';
 import { CombineElementProps } from 'src/types/utils';
 
 interface AlertIcon {
@@ -14,19 +13,19 @@ const alertIconMap: {
   [key in SemanticColor]: AlertIcon;
 } = {
   negative: {
-    icon: closeCircle,
+    icon: 'close-circle',
     color: colors.red50,
   },
   notice: {
-    icon: alertCircle,
+    icon: 'alert-circle',
     color: colors.yellow50,
   },
   informative: {
-    icon: informationCircle,
+    icon: 'information-circle',
     color: colors.blue50,
   },
   positive: {
-    icon: checkmarkCircle,
+    icon: 'checkmark-circle',
     color: colors.green50,
   },
 };
@@ -53,7 +52,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
     >
       <Icon
         className="lubycon-alert__icon"
-        icon={iconName}
+        name={iconName}
         type="filled"
         size={19}
         color={iconColor}

--- a/ui-kit/src/components/Icon/index.tsx
+++ b/ui-kit/src/components/Icon/index.tsx
@@ -17,7 +17,10 @@ type Props = CombineElementProps<
   }
 >;
 
-const TestIcon = ({
+/** ionicons의 아이콘을 사용합니다
+ *  https://ionicons.com/
+ */
+const Icon = ({
   name,
   size = 16,
   type = 'filled',
@@ -89,7 +92,7 @@ const TestIcon = ({
   );
 };
 
-export default TestIcon;
+export default Icon;
 
 async function fetchIcon(name: string) {
   const response = await fetch(getIconUrl(name));

--- a/ui-kit/src/components/Icon/index.tsx
+++ b/ui-kit/src/components/Icon/index.tsx
@@ -1,28 +1,59 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import classnames from 'classnames';
 import { colors } from 'src/constants/colors';
+import { CombineElementProps } from 'src/types/utils';
 
-/**
- * UI Kit 내부에서만 사용
- */
+const iconCache: Record<string, string> = {};
 
-interface Props {
-  icon: string;
-  size?: number;
-  type: 'outline' | 'filled';
-  color?: string;
-  className?: string;
-}
+export type IconType = 'outline' | 'filled' | 'sharp';
+type Props = CombineElementProps<
+  'span',
+  {
+    name: string;
+    size?: number;
+    type?: IconType;
+    color?: string;
+    className?: string;
+  }
+>;
 
-const Icon = ({ icon, size = 16, type, color = colors.gray100, className }: Props) => {
-  const svgTag = useMemo(() => {
-    return icon.replace(/data:image\/svg\+xml;utf8,/, '');
-  }, [icon]);
+const TestIcon = ({
+  name,
+  size = 16,
+  type = 'filled',
+  color = colors.gray100,
+  className,
+  ...rest
+}: Props) => {
+  const targetAttr = type === 'outline' ? 'stroke' : 'fill';
+  const iconName = getIconName(name, type);
 
-  const coloredSvg = useMemo(() => {
-    const targetAttr = type === 'outline' ? 'stroke' : 'fill';
-    return svgTag.replace(/(<path\s)\b/gm, `$1${targetAttr}="${color}" `);
-  }, [svgTag, color]);
+  const [iconHTML, setIconHTML] = useState<string | undefined>(iconCache[iconName]);
+  const [showFallbackIcon, setShowFallbackIcon] = useState(false);
+
+  useEffect(() => {
+    if (iconHTML != null) {
+      return;
+    }
+
+    let ignore = false;
+
+    (async function () {
+      try {
+        const data = await fetchIcon(iconName);
+        if (!ignore) {
+          setIconHTML(data);
+          iconCache[iconName] = data;
+        }
+      } catch {
+        setShowFallbackIcon(true);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
   return (
     <span
@@ -35,9 +66,45 @@ const Icon = ({ icon, size = 16, type, color = colors.gray100, className }: Prop
         className
       )}
       style={{ width: size, height: size }}
-      dangerouslySetInnerHTML={{ __html: coloredSvg }}
-    />
+      {...rest}
+    >
+      <span
+        style={{ width: size, height: size, [targetAttr]: color, color }}
+        className={classnames('lubycon-icon__icon-body', {
+          'lubycon-icon__icon-body--hide-origin-icon': showFallbackIcon,
+        })}
+        aria-label={name}
+        aria-hidden={iconHTML == null}
+        dangerouslySetInnerHTML={iconHTML ? { __html: iconHTML } : undefined}
+        role="img"
+      />
+      <img
+        src={getIconUrl(iconName)}
+        className={classnames('lubycon-icon__fallback-icon', {
+          'lubycon-icon__fallback-icon--show-fallback-icon': showFallbackIcon,
+        })}
+        alt={name}
+      />
+    </span>
   );
 };
 
-export default Icon;
+export default TestIcon;
+
+async function fetchIcon(name: string) {
+  const response = await fetch(getIconUrl(name));
+  const body = await response.text();
+  if (response.ok) {
+    return body;
+  } else {
+    throw new Error(body);
+  }
+}
+
+function getIconName(name: string, type: IconType) {
+  return type === 'filled' ? name : `${name}-${type}`;
+}
+
+function getIconUrl(name: string) {
+  return `https://icons.lubycon.io/${name}.svg`;
+}

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, Ref } from 'react';
 import { CombineElementProps } from 'src/types/utils';
 import classnames from 'classnames';
-import { chevronDownOutline } from 'ionicons/icons';
 import Icon from 'components/Icon';
 import { colors } from 'src/constants/colors';
 import { useState } from 'react';
@@ -55,7 +54,7 @@ const Selection = (
         </option>
         {children}
       </select>
-      <Icon icon={chevronDownOutline} type="outline" color={iconColor} />
+      <Icon name="chevron-down" type="outline" color={iconColor} />
     </div>
   );
 };

--- a/ui-kit/src/components/Tag/index.tsx
+++ b/ui-kit/src/components/Tag/index.tsx
@@ -4,7 +4,6 @@ import { CombineElementProps } from 'src/types/utils';
 import classnames from 'classnames';
 import Text from '../Text';
 import Icon from '../Icon';
-import { close } from 'ionicons/icons';
 
 export type TagType = SemanticColor | 'default';
 
@@ -44,7 +43,7 @@ const Tag = ({
       </span>
       {onDelete != null ? (
         <a className="lubycon-tag__delete-button" onClick={() => onDelete?.(label)}>
-          <Icon icon={close} type="filled" color={colors.gray70} />
+          <Icon name="close" type="filled" color={colors.gray70} />
         </a>
       ) : null}
     </div>

--- a/ui-kit/src/index.ts
+++ b/ui-kit/src/index.ts
@@ -28,3 +28,4 @@ export { default as Table, TableHead, TableBody, TableRow, TableCell } from './c
 export { Portal } from './contexts/Portal';
 export { useSnackbar } from './contexts/Snackbar';
 export { colors } from './constants/colors';
+export { default as Icon } from './components/Icon';

--- a/ui-kit/src/sass/components/_Icon.scss
+++ b/ui-kit/src/sass/components/_Icon.scss
@@ -17,8 +17,9 @@
   }
   &__fallback-icon {
     display: none;
+    vertical-align: top;
     &--show-fallback-icon {
-      display: inline;
+      display: inline-block;
     }
   }
   svg {

--- a/ui-kit/src/sass/components/_Icon.scss
+++ b/ui-kit/src/sass/components/_Icon.scss
@@ -10,6 +10,17 @@
       stroke: transparent;
     }
   }
+  &__icon-body {
+    &--hide-origin-icon {
+      display: none;
+    }
+  }
+  &__fallback-icon {
+    display: none;
+    &--show-fallback-icon {
+      display: inline;
+    }
+  }
   svg {
     width: 100%;
     vertical-align: top;

--- a/ui-kit/src/sass/index.scss
+++ b/ui-kit/src/sass/index.scss
@@ -1,3 +1,7 @@
 @import './functions/index';
 @import './utils/index';
 @import './components/index.scss';
+
+body {
+  font-size: 16px;
+}

--- a/ui-kit/src/sass/utils/_typography.scss
+++ b/ui-kit/src/sass/utils/_typography.scss
@@ -2,29 +2,29 @@
   $font-size-number: strip-unit($font-size);
 
   :root {
-    --lubycon-font-size-#{$font-size-number}: #{$font-size};
-    --lubycon-line-height-#{$font-size-number}: #{$line-height};
+    --lubycon-font-size-#{$name}: #{$font-size};
+    --lubycon-line-height-#{$name}: #{$line-height};
   }
 
-  .lubycon-font-size-#{$font-size-number} {
+  .lubycon-font-size-#{$name} {
     font-size: $font-size;
-    font-size: var(--lubycon-font-size-#{$font-size-number});
+    font-size: var(--lubycon-font-size-#{$name});
     line-height: $line-height;
-    line-height: var(--lubycon-line-height-#{$font-size-number});
+    line-height: var(--lubycon-line-height-#{$name});
   }
 
   .lubycon-typography-#{$name} {
-    @extend .lubycon-font-size-#{$font-size-number};
+    @extend .lubycon-font-size-#{$name};
   }
 }
 
-@include _typography('h1', 42px, 64px);
-@include _typography('h2', 32px, 48px);
-@include _typography('h3', 28px, 42px);
-@include _typography('h4', 26px, 40px);
-@include _typography('h5', 24px, 36px);
-@include _typography('h6', 20px, 30px);
-@include _typography('subtitle', 18px, 30px);
-@include _typography('p1', 16px, 32px);
-@include _typography('p2', 14px, 24px);
-@include _typography('caption', 12px, 20px);
+@include _typography('h1', 2.625rem, 1.5);
+@include _typography('h2', 2rem, 1.5);
+@include _typography('h3', 1.75rem, 1.5);
+@include _typography('h4', 1.625rem, 1.5);
+@include _typography('h5', 1.5rem, 1.5);
+@include _typography('h6', 1.25rem, 1.5);
+@include _typography('subtitle', 1.125rem, 1.7);
+@include _typography('p1', 1rem, 2);
+@include _typography('p2', 0.9375rem, 1.7);
+@include _typography('caption', 0.75rem, 1.6);

--- a/ui-kit/src/stories/Card.stories.tsx
+++ b/ui-kit/src/stories/Card.stories.tsx
@@ -13,7 +13,6 @@ import {
 } from 'src';
 import Icon from 'components/Icon';
 import { Meta } from '@storybook/react/types-6-0';
-import { arrowForward } from 'ionicons/icons';
 
 export default {
   title: 'Lubycon UI Kit/Card',
@@ -44,7 +43,7 @@ export const Default = () => {
             <Text typography="caption" style={{ color: colors.gray60, marginRight: 5 }}>
               더보기
             </Text>
-            <Icon icon={arrowForward} type="outline" color={colors.gray60} />
+            <Icon name="arrow-forward" type="outline" color={colors.gray60} />
           </span>
         </CardFooter>
       </Card>
@@ -67,7 +66,7 @@ export const ImageCard = () => {
               <Text typography="caption" style={{ color: colors.gray60, marginRight: 5 }}>
                 더보기
               </Text>
-              <Icon icon={arrowForward} type="outline" color={colors.gray60} />
+              <Icon name="arrow-forward" type="outline" color={colors.gray60} />
             </span>
           </CardFooter>
         </Card>

--- a/ui-kit/src/stories/Icon.stories.tsx
+++ b/ui-kit/src/stories/Icon.stories.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Icon, Text } from 'src';
+import { IconType } from 'src/components/Icon';
+import { Meta } from '@storybook/react/types-6-0';
+import { ColorProperty, colors } from 'src/constants/colors';
+import { Fragment } from 'react';
+
+export default {
+  title: 'Lubycon UI Kit/Icon',
+  component: Icon,
+} as Meta;
+
+const Spacer = () => {
+  return <div style={{ height: 20 }} />;
+};
+
+const icons = ['code', 'accessibility', 'alarm', 'airplane'];
+export const Default = () => {
+  return (
+    <div>
+      <Text>
+        아이콘 이름은
+        <a href="https://github.com/Lubycon/lubycon-icons" target="_blank" rel="noreferrer">
+          https://github.com/Lubycon/lubycon-icons
+        </a>
+        를 참고하세요.
+      </Text>
+      <br />
+      <div>
+        {icons.map((icon) => (
+          <Fragment key={icon}>
+            <Icon name={icon} size={30} />
+            <Spacer />
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const colorKeys = Object.keys(colors);
+export const Color = () => {
+  return (
+    <>
+      {colorKeys.map((key) => {
+        const colorKey = key as ColorProperty;
+        return (
+          <Fragment key={colorKey}>
+            <div style={{ display: 'flex' }}>
+              <Icon name="apps" size={30} color={colors[colorKey]} />
+              <Icon name="apps" size={30} color={colors[colorKey]} type="outline" />
+              <Icon name="apps" size={30} color={colors[colorKey]} type="sharp" />
+            </div>
+            <Spacer />
+          </Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+const types: IconType[] = ['filled', 'outline', 'sharp'];
+
+export const Types = () => {
+  return (
+    <>
+      {types.map((type) => (
+        <Fragment key={type}>
+          <Text>{type}</Text>
+          <br />
+          <Icon name="accessibility" size={50} color={colors.blue50} type={type} />
+          <Spacer />
+        </Fragment>
+      ))}
+    </>
+  );
+};

--- a/ui-kit/src/stories/Input.stories.tsx
+++ b/ui-kit/src/stories/Input.stories.tsx
@@ -49,7 +49,7 @@ export const Error = () => {
       onChange={(e) => setValue(e.target.value)}
       right={
         isError ? null : (
-          <Icon icon={checkmarkCircle} type="filled" color={colors.green50} size={20} />
+          <Icon name="checkmark-circle" type="filled" color={colors.green50} size={20} />
         )
       }
     />
@@ -79,12 +79,12 @@ export const Types = () => {
 export const LeftAndRight = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', maxWidth: 300 }}>
-      <Input label={'Left Area'} left={<Icon icon={musicalNote} type="filled" />} />
-      <Input label={'Right Area'} right={<Icon icon={closeCircle} type="filled" />} />
+      <Input label={'Left Area'} left={<Icon name="musical-note" type="filled" />} />
+      <Input label={'Right Area'} right={<Icon name="close-circle" type="filled" />} />
       <Input
         label={'Left And Right'}
-        left={<Icon icon={musicalNote} type="filled" />}
-        right={<Icon icon={closeCircle} type="filled" />}
+        left={<Icon name="musical-note" type="filled" />}
+        right={<Icon name="close-circle" type="filled" />}
       />
     </div>
   );

--- a/ui-kit/src/stories/List.stories.tsx
+++ b/ui-kit/src/stories/List.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button, List, ListItem, ListItemImage, colors } from 'src';
 import { Meta } from '@storybook/react/types-6-0';
 import Icon from 'src/components/Icon';
-import { chevronForward } from 'ionicons/icons';
 
 export default {
   title: 'Lubycon UI Kit/List',
@@ -88,7 +87,7 @@ export const LeftRight = () => {
       <ListItem
         title="버튼 조합형"
         content="자세히 보려면 클릭하세요"
-        right={<Icon icon={chevronForward} type="outline" size={24} color={colors.gray60} />}
+        right={<Icon name="chevron-forward" type="outline" size={24} color={colors.gray60} />}
         onClick={noop}
       />
       <ListItem
@@ -100,7 +99,7 @@ export const LeftRight = () => {
         left={<ListItemImage src="http://cogulmars.cafe24.com/img/04about_img01.png" />}
         title="썸네일 + 버튼 조합형"
         content="자세히 보려면 클릭하세요"
-        right={<Icon icon={chevronForward} type="outline" size={24} color={colors.gray60} />}
+        right={<Icon name="chevron-forward" type="outline" size={24} color={colors.gray60} />}
         onClick={noop}
       />
     </List>

--- a/ui-kit/src/utils/mediaQuery.ts
+++ b/ui-kit/src/utils/mediaQuery.ts
@@ -22,7 +22,6 @@ export function isMatchedXS() {
   return !isMatchMinWidth('xs');
 }
 export function isMatchedSM() {
-  console.log(!isMatchMinWidth('sm'));
   return !isMatchMinWidth('sm');
 }
 export function isMatchedMD() {


### PR DESCRIPTION
## 변경사항
- 타이포그래피가 `rem` 단위로 변경되었습니다
- `ionicons`를 제거하고 [https://icons.lubycon.io](https://icons.lubycon.io) 에서 아이콘을 받아오도록 변경합니다. (번들 사이즈 2.7MB -> 1.1MB)
- 이제 `Icon` 컴포넌트를 ui-kit 모듈에 포함합니다.
- `Icon` 컴포넌트 스토리북을 작성했습니다.

![스크린샷 2021-04-07 오후 9 32 59](https://user-images.githubusercontent.com/19145342/113870442-d06fdc80-97ec-11eb-9d46-1fcd87f58dcd.png)

![스크린샷 2021-04-07 오후 9 32 44](https://user-images.githubusercontent.com/19145342/113870363-bcc47600-97ec-11eb-8dd0-81481c696b0d.png)


## 디자인 시안 링크
https://www.figma.com/file/e5zHg6E5rgkKw4v47EFXVe/Lubycon-UI-Library?node-id=0%3A1

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇‍♂️
