### PR TITLE
Chore/code highlight

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.1.5",
     "@lubycon/ui-kit": "^1.1.0-alpha.30",
     "gh-pages": "^3.1.0",
+    "highlight.js": "^10.7.2",
     "next": "latest",
     "normalize.css": "^8.0.1",
     "react": "^16.12.0",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -4,6 +4,7 @@ import { LubyconUIKitProvider } from '@lubycon/ui-kit';
 
 import 'normalize.css';
 import '@lubycon/ui-kit/css/lubycon-ui-kit.min.css';
+import 'highlight.js/styles/stackoverflow-light.css';
 import Head from 'next/head';
 
 export default function LubyconUIKitDocsApp({ Component, pageProps }: AppProps) {

--- a/docs/src/components/CodeHighlight/index.tsx
+++ b/docs/src/components/CodeHighlight/index.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, PropsWithChildren } from 'react';
+import hljs from 'highlight.js';
+import javascript from 'highlight.js/lib/languages/javascript';
+import bash from 'highlight.js/lib/languages/bash';
+import css from 'highlight.js/lib/languages/css';
+import scss from 'highlight.js/lib/languages/scss';
+import typescript from 'highlight.js/lib/languages/typescript';
+
+interface Props {
+  lang: 'ts' | 'js' | 'bash' | 'css' | 'scss';
+}
+
+const Highlight = ({ lang, children }: PropsWithChildren<Props>) => {
+
+  useEffect(() => {
+    hljs.registerLanguage('js', javascript);
+    hljs.registerLanguage('bash', bash);
+    hljs.registerLanguage('css', css);
+    hljs.registerLanguage('scss', scss);
+    hljs.registerLanguage('ts', typescript);
+    hljs.highlightAll();
+  }, []);
+
+  return (
+    <pre>
+      <code className={lang}>
+        { children }
+      </code>
+    </pre>
+  )
+};
+
+export default Highlight;

--- a/docs/src/pages/GettingStartedPage/index.tsx
+++ b/docs/src/pages/GettingStartedPage/index.tsx
@@ -1,5 +1,6 @@
 import BasicLayout from 'components/BasicLayout';
 import PostSection from 'components/PostSection';
+import Highlight from 'components/CodeHighlight';
 import React from 'react';
 
 const GettingStartedPage = () => {
@@ -11,18 +12,18 @@ const GettingStartedPage = () => {
             Lubycon UI Kit은 아직 알파 버전만 배포된 상태입니다. 따라서 문서 상단의 버전을 확인하고
             latest가 아닌 정확한 버전을 명시하여 설치하시는 것을 추천합니다.
           </PostSection.Contents>
-          <pre>
+          <Highlight lang="bash">
             {`$ npm install @lubycon/ui-kit@v1.1.0-alpha.24
 // or
 $ yarn add @lubycon/ui-kit@v1.1.0-alpha.24`}
-          </pre>
+          </Highlight>
         </PostSection>
         <PostSection title={<PostSection.Title>Usage</PostSection.Title>}>
           <PostSection.Contents>
             Lubycon UI Kit 내부의 몇몇 컴포넌트는 컴포넌트 트리와 분리된 상태와 렌더 트리를 가지고
             있기 때문에 LubyconUIKitProvider을 필요로 합니다.
           </PostSection.Contents>
-          <pre>
+          <Highlight lang="ts">
             {`// App.tsx
 
 import React, { PropsWithChildren } from 'react';
@@ -31,7 +32,7 @@ import { LubyconUIKitProvider } from '@lubycon/ui-kit';
 function App({ children }: PropsWithChildren<{}>) {
   return <LubyconUIKitProvider>{children}</LubyconUIKitProvider>;
 }`}
-          </pre>
+          </Highlight>
         </PostSection>
         <PostSection title={<PostSection.Title>선언적 렌더링 vs Hooks</PostSection.Title>}>
           <PostSection.Contents>
@@ -42,7 +43,7 @@ function App({ children }: PropsWithChildren<{}>) {
             선언적인 방법과 명령적인 방법을 선택해서 사용할 수 있도록 지원하고 있습니다.
           </PostSection.Contents>
           <PostSection.Subtitle>선언적 렌더링</PostSection.Subtitle>
-          <pre>
+          <Highlight lang="ts">
             {`import React, { useState } from 'react';
 import { Toast } from '@lubycon/ui-kit';
 
@@ -58,9 +59,9 @@ function Foo() {
 }
 
 export default Foo;`}
-          </pre>
+          </Highlight>
           <PostSection.Subtitle>Hooks</PostSection.Subtitle>
-          <pre>
+          <Highlight lang="ts">
             {`import React from 'react';
 import { useToast, Button } from '@lubycon/ui-kit';
 
@@ -79,7 +80,7 @@ function Foo() {
 }
 
 export default Foo;`}
-          </pre>
+          </Highlight>
         </PostSection>
       </div>
     </BasicLayout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8914,6 +8914,11 @@ highlight.js@^10.1.1, highlight.js@~10.4.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
   integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
 
+highlight.js@^10.7.2:
+  version "10.7.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
+  integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
> 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요!

## 변경사항
- 코드 하이라이팅 라이브러리 추가 + 기존 소스에 적용

## 디자인 시안 링크
- docs 티켓
  - https://www.notion.so/lubycon/8a2aadff0e9d4b9f88ccd1d9b41436f0?v=f7c51467136c422ba22c789b7ad7acf2&p=52ad498b250c48f1932a4acd2791592b

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
- prism.js / highlight.js 선택 사유
  - 두 개 사이에 큰 차이가 없어서 처음에 prism.js 사용하려고 했는데요.
  - prism.js 내부에서 하이라이팅 메서드를 처리할 때 클래스명에 빈 공백 문자열을 넣어주는 부분이 있어서 클라이언트와 서버간 클래스명이 달라집니다
  - 제 생각에 해당 부분은 라이브러리 차원에서의 수정이 없으면 손보기가 힘들어서 highlight.js로 변경하게 되었습니다.
- 코드 하이라이팅 컴포넌트가 별도로 추가돼도 괜찮은지?
  - 일단 최대한 간편하게 쓰는게 좋지 않을까 하는 생각으로 별도로 컴포넌트 추가해주었습니다
- 코드 하이라이팅 컴포넌트 괜찮다면 현재 네이밍 괜찮은지? (개인적으로는 더 줄이고 싶습니다)
