### PR TITLE
feat(ui-kit): 모든 컴포넌트가 HTML 엘리먼트를 상속받도록 수정

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -1,0 +1,16 @@
+name: PR Slack Notification
+on: [pull_request]
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    name: Run
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Fire Notification
+        uses: Lubycon/github-reviewer-slack-noti-action@v1.1.3
+        with:
+          slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
+          channel-id: C01TJJY15BP

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -21,8 +21,10 @@ module.exports = {
     ["@semantic-release/commit-analyzer", {
       "preset": "angular",
       "releaseRules": [
+        {"type": "feat", "release": "minor"},
         {"type": "chore", "release": "patch"},
         {"type": "refactor", "release": "patch"},
+        {"type": "fix", "release": "patch"},
         {"type": "style", "release": "patch"}
       ],
       "parserOpts": {

--- a/ui-kit/src/components/Card/CardContent.tsx
+++ b/ui-kit/src/components/Card/CardContent.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { ReactNode } from 'react';
 import classnames from 'classnames';
+import { CombineElementProps } from 'src/types/utils';
 
-interface CardContentProps {
-  children?: ReactNode;
-}
-const CardContent = ({ children }: CardContentProps) => {
-  return <div className={classnames('lubycon-card__content')}>{children}</div>;
+type CardContentProps = CombineElementProps<
+  'div',
+  {
+    children?: ReactNode;
+  }
+>;
+const CardContent = ({ children, className, ...props }: CardContentProps) => {
+  return (
+    <div className={classnames('lubycon-card__content', className)} {...props}>
+      {children}
+    </div>
+  );
 };
 
 export default CardContent;

--- a/ui-kit/src/components/Card/CardFooter.tsx
+++ b/ui-kit/src/components/Card/CardFooter.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 import { ReactNode } from 'react';
 import classnames from 'classnames';
+import { CombineElementProps } from 'src/types/utils';
 
-interface CardFooterProps {
-  children?: ReactNode;
-  justifyContent?: 'flex-start' | 'center' | 'flex-end';
-}
-const CardFooter = ({ children, justifyContent = 'flex-start' }: CardFooterProps) => {
+type CardFooterProps = CombineElementProps<
+  'div',
+  {
+    children?: ReactNode;
+    justifyContent?: 'flex-start' | 'center' | 'flex-end';
+  }
+>;
+const CardFooter = ({
+  children,
+  justifyContent = 'flex-start',
+  className,
+  ...props
+}: CardFooterProps) => {
   return (
     <div
       className={classnames(
         'lubycon-card__footer',
-        `lubycon-card__footer--align-${justifyContent}`
+        `lubycon-card__footer--align-${justifyContent}`,
+        className
       )}
+      {...props}
     >
       {children}
     </div>

--- a/ui-kit/src/components/Card/CardHeader.tsx
+++ b/ui-kit/src/components/Card/CardHeader.tsx
@@ -1,13 +1,17 @@
 import React, { ReactNode, isValidElement } from 'react';
 import classnames from 'classnames';
 import Text from '../Text';
+import { CombineElementProps } from 'src/types/utils';
 
-interface CardHeaderProps {
-  children?: ReactNode;
-}
-const CardHeader = ({ children }: CardHeaderProps) => {
+type CardHeaderProps = CombineElementProps<
+  'div',
+  {
+    children?: ReactNode;
+  }
+>;
+const CardHeader = ({ children, className, ...props }: CardHeaderProps) => {
   return (
-    <div className={classnames('lubycon-card__header')}>
+    <div className={classnames('lubycon-card__header', className)} {...props}>
       {isValidElement(children) ? children : <Text typography="h6">{children}</Text>}
     </div>
   );

--- a/ui-kit/src/components/Card/index.tsx
+++ b/ui-kit/src/components/Card/index.tsx
@@ -1,14 +1,25 @@
 import React, { forwardRef } from 'react';
 import { ReactNode } from 'react';
 import classnames from 'classnames';
+import { CombineElementProps } from 'src/types/utils';
 
-interface Props {
-  children: ReactNode;
-}
+type Props = CombineElementProps<
+  'div',
+  {
+    children: ReactNode;
+  }
+>;
 
-const Card = forwardRef<HTMLDivElement, Props>(function Card({ children }, ref) {
+const Card = forwardRef<HTMLDivElement, Props>(function Card(
+  { children, className, ...props },
+  ref
+) {
   return (
-    <div ref={ref} className={classnames('lubycon-card', 'lubycon-shadow--2')}>
+    <div
+      ref={ref}
+      className={classnames('lubycon-card', 'lubycon-shadow--2', className)}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/ui-kit/src/components/Checkbox/index.tsx
+++ b/ui-kit/src/components/Checkbox/index.tsx
@@ -11,7 +11,7 @@ interface CheckboxBaseProps {
 type CheckboxProps = Omit<CombineElementProps<'input', CheckboxBaseProps>, 'type'>;
 
 const Checkbox = (
-  { label, display = 'block', style, disabled, ...props }: CheckboxProps,
+  { label, display = 'block', style, disabled, className, ...props }: CheckboxProps,
   ref: Ref<HTMLInputElement>
 ) => {
   const id = generateID('checkbox');
@@ -19,9 +19,14 @@ const Checkbox = (
   return (
     <label
       role="checkbox"
-      className={classnames('lubycon-checkbox', `lubycon-checkbox--display-${display}`, {
-        'lubycon-checkbox--disabled': disabled,
-      })}
+      className={classnames(
+        'lubycon-checkbox',
+        `lubycon-checkbox--display-${display}`,
+        {
+          'lubycon-checkbox--disabled': disabled,
+        },
+        className
+      )}
       style={style}
     >
       <span className="lubycon-checkbox__input">

--- a/ui-kit/src/components/Modal/ModalContent.tsx
+++ b/ui-kit/src/components/Modal/ModalContent.tsx
@@ -4,18 +4,19 @@ import Text from 'components/Text';
 import { Typographys } from 'components/Text/types';
 import { CombineElementProps } from 'types/utils';
 
-interface BaseProps {
-  size?: 'small' | 'medium';
-  children?: ReactNode;
-}
+type ModalContentProps = CombineElementProps<
+  'div',
+  {
+    size?: 'small' | 'medium';
+    children?: ReactNode;
+  }
+>;
 
-type ModalContentProps = CombineElementProps<'div', BaseProps>;
-
-const ModalContent = ({ children, size }: ModalContentProps) => {
+const ModalContent = ({ children, size, className, ...props }: ModalContentProps) => {
   const typography: Typographys = size === 'small' ? 'p2' : 'p1';
 
   return (
-    <div className={classnames('lubycon-modal__content')}>
+    <div className={classnames('lubycon-modal__content', className)} {...props}>
       {isValidElement(children) ? children : <Text typography={typography}>{children}</Text>}
     </div>
   );

--- a/ui-kit/src/components/Modal/ModalFooter.tsx
+++ b/ui-kit/src/components/Modal/ModalFooter.tsx
@@ -1,11 +1,20 @@
 import React, { ReactNode } from 'react';
+import { CombineElementProps } from 'src/types/utils';
+import classnames from 'classnames';
 
-interface ModalFooterProps {
-  children?: ReactNode;
-}
+type ModalFooterProps = CombineElementProps<
+  'div',
+  {
+    children?: ReactNode;
+  }
+>;
 
-const ModalFooter = ({ children }: ModalFooterProps) => {
-  return <div className="lubycon-modal__footer">{children}</div>;
+const ModalFooter = ({ children, className, ...props }: ModalFooterProps) => {
+  return (
+    <div className={classnames('lubycon-modal__footer', className)} {...props}>
+      {children}
+    </div>
+  );
 };
 
 export default ModalFooter;

--- a/ui-kit/src/components/Modal/ModalHeader.tsx
+++ b/ui-kit/src/components/Modal/ModalHeader.tsx
@@ -1,17 +1,22 @@
 import React, { ReactNode, isValidElement } from 'react';
 import Text from 'components/Text';
 import { Typographys } from 'components/Text/types';
+import { CombineElementProps } from 'src/types/utils';
+import classnames from 'classnames';
 
-interface ModalHeaderProps {
-  size?: 'small' | 'medium';
-  children?: ReactNode;
-}
+type ModalHeaderProps = CombineElementProps<
+  'div',
+  {
+    size?: 'small' | 'medium';
+    children?: ReactNode;
+  }
+>;
 
-const ModalHeader = ({ size, children }: ModalHeaderProps) => {
+const ModalHeader = ({ size, children, className, ...props }: ModalHeaderProps) => {
   const typography: Typographys = size === 'small' ? 'subtitle' : 'h6';
 
   return (
-    <header className="lubycon-modal__title">
+    <header className={classnames('lubycon-modal__title', className)} {...props}>
       {isValidElement(children) ? children : <Text typography={typography}>{children}</Text>}
     </header>
   );

--- a/ui-kit/src/components/Modal/ModalWindow.tsx
+++ b/ui-kit/src/components/Modal/ModalWindow.tsx
@@ -1,14 +1,21 @@
 import React, { ReactNode } from 'react';
 import classnames from 'classnames';
+import { CombineElementProps } from 'src/types/utils';
 
-interface ModalWindowProps {
-  children: ReactNode;
-  size: 'small' | 'medium';
-}
+type ModalWindowProps = CombineElementProps<
+  'div',
+  {
+    children: ReactNode;
+    size: 'small' | 'medium';
+  }
+>;
 
-const ModalWindow = ({ children, size }: ModalWindowProps) => {
+const ModalWindow = ({ children, size, className, ...props }: ModalWindowProps) => {
   return (
-    <div className={classnames('lubycon-modal__window', `lubycon-modal__window--${size}`)}>
+    <div
+      className={classnames('lubycon-modal__window', `lubycon-modal__window--${size}`, className)}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/ui-kit/src/components/Modal/index.tsx
+++ b/ui-kit/src/components/Modal/index.tsx
@@ -4,16 +4,28 @@ import ModalWindow from './ModalWindow';
 import { generateID } from 'utils/index';
 import { animated, useTransition } from 'react-spring';
 import { useState } from 'react';
+import { CombineElementProps } from 'src/types/utils';
 
-export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
-  show: boolean;
-  size?: 'small' | 'medium';
-  children: ReactElement | ReactElement[];
-  onOpen?: () => void;
-  onClose?: () => void;
-}
+export type ModalProps = CombineElementProps<
+  'div',
+  {
+    show: boolean;
+    size?: 'small' | 'medium';
+    children: ReactElement | ReactElement[];
+    onOpen?: () => void;
+    onClose?: () => void;
+  }
+>;
 
-const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) => {
+const Modal = ({
+  show,
+  size = 'small',
+  children,
+  onOpen,
+  onClose,
+  className,
+  ...props
+}: ModalProps) => {
   const [showModal, setShowModal] = useState(show);
   const backdropRef = useRef(null);
   const backdropTransition = useTransition(showModal, null, {
@@ -68,10 +80,14 @@ const Modal = ({ show, size = 'small', children, onOpen, onClose }: ModalProps) 
           )
       )}
       {modalTransition.map(
-        ({ item: show, key, props }) =>
+        ({ item: show, key, props: animationProps }) =>
           show && (
-            <animated.div key={key} style={props} className="lubycon-modal__window-wrapper">
-              <ModalWindow size={size}>
+            <animated.div
+              key={key}
+              style={animationProps}
+              className="lubycon-modal__window-wrapper"
+            >
+              <ModalWindow size={size} className={className} {...props}>
                 {Children.map(children, (child) => {
                   return cloneElement(child, {
                     key: generateID('lubycon-modal__children'),

--- a/ui-kit/src/components/Radio/index.tsx
+++ b/ui-kit/src/components/Radio/index.tsx
@@ -11,16 +11,21 @@ interface RadioBaseProps {
 type RadioProps = Omit<CombineElementProps<'input', RadioBaseProps>, 'type'>;
 
 const Radio = (
-  { label, display = 'block', style, disabled, ...props }: RadioProps,
+  { label, display = 'block', style, disabled, className, ...props }: RadioProps,
   ref: Ref<HTMLInputElement>
 ) => {
   const id = generateID('radio');
 
   return (
     <span
-      className={classnames('lubycon-radio', `lubycon-radio--display-${display}`, {
-        'lubycon-radio--disabled': disabled,
-      })}
+      className={classnames(
+        'lubycon-radio',
+        `lubycon-radio--display-${display}`,
+        {
+          'lubycon-radio--disabled': disabled,
+        },
+        className
+      )}
       style={style}
     >
       <label htmlFor={id} className="lubycon-radio__label">

--- a/ui-kit/src/components/Selection/index.tsx
+++ b/ui-kit/src/components/Selection/index.tsx
@@ -21,6 +21,7 @@ const Selection = (
     value,
     onChange,
     size = 'medium',
+    className,
     ...props
   }: SelectionProps,
   ref: Ref<HTMLSelectElement>
@@ -33,10 +34,15 @@ const Selection = (
 
   return (
     <div
-      className={classnames('lubycon-selection', `lubycon-selection--size-${size}`, {
-        'lubycon-selection--disabled': disabled,
-        'lubycon-selection--empty': innerValue === '',
-      })}
+      className={classnames(
+        'lubycon-selection',
+        `lubycon-selection--size-${size}`,
+        {
+          'lubycon-selection--disabled': disabled,
+          'lubycon-selection--empty': innerValue === '',
+        },
+        className
+      )}
     >
       <select
         ref={ref}

--- a/ui-kit/src/components/Switch/index.tsx
+++ b/ui-kit/src/components/Switch/index.tsx
@@ -11,7 +11,7 @@ interface SwitchBaseProps {
 type SwitchProps = Omit<CombineElementProps<'input', SwitchBaseProps>, 'type'>;
 
 const Switch = (
-  { label, display = 'block', style, ...props }: SwitchProps,
+  { label, display = 'block', style, className, ...props }: SwitchProps,
   ref: Ref<HTMLInputElement>
 ) => {
   const id = generateID('switch');
@@ -19,7 +19,7 @@ const Switch = (
   return (
     <label
       role="switch"
-      className={classnames('lubycon-switch', `lubycon-switch--display-${display}`)}
+      className={classnames('lubycon-switch', `lubycon-switch--display-${display}`, className)}
       style={style}
     >
       <input className="lubycon-switch__input" ref={ref} type="checkbox" {...props} id={id} />

--- a/ui-kit/src/components/Table/TableBody.tsx
+++ b/ui-kit/src/components/Table/TableBody.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import classnames from 'classnames';
-import { TableProps } from './index';
+import { TableProps } from './props';
 
-const TableBody = ({ children }: TableProps) => {
+const TableBody = ({ children, className, ...props }: TableProps<HTMLTableSectionElement>) => {
   return (
-    <tbody className={classnames('lubycon-table__body', 'lubycon-font-weight--regular')}>
+    <tbody
+      className={classnames('lubycon-table__body', 'lubycon-font-weight--regular', className)}
+      {...props}
+    >
       {children}
     </tbody>
   );

--- a/ui-kit/src/components/Table/TableCell.tsx
+++ b/ui-kit/src/components/Table/TableCell.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import classnames from 'classnames';
-import { TableProps } from './index';
+import { TableProps } from './props';
 import { useTableHeadContext } from './TableHead';
+import { Combine } from 'src/types/utils';
 
-interface TableCellProps extends TableProps {
-  as?: 'th' | 'td';
-}
+type TableCellProps = Combine<
+  TableProps<HTMLTableHeaderCellElement | HTMLTableDataCellElement>,
+  {
+    as?: 'th' | 'td';
+  }
+>;
 
-const TableCell = ({ children, align = 'left', as }: TableCellProps) => {
+const TableCell = ({ children, align = 'left', className, as, ...props }: TableCellProps) => {
   const { variant } = useTableHeadContext();
   const isHeadCell = variant === 'head' ? 'th' : 'td';
   const Component = as ?? isHeadCell;
 
   return (
-    <Component className={classnames('lubycon-table__cell', `lubycon-table--align-${align}`)}>
+    <Component
+      className={classnames('lubycon-table__cell', `lubycon-table--align-${align}`, className)}
+      {...props}
+    >
       {children}
     </Component>
   );

--- a/ui-kit/src/components/Table/TableHead.tsx
+++ b/ui-kit/src/components/Table/TableHead.tsx
@@ -1,13 +1,15 @@
-import React, { createContext } from 'react';
-import { useContext } from 'react';
-import { TableProps } from './index';
+import React, { createContext, useContext } from 'react';
+import classnames from 'classnames';
+import { TableProps } from './props';
 
 const TableHeadContext = createContext({ variant: '' });
 
-const TableHead = ({ children }: TableProps) => {
+const TableHead = ({ children, className, ...props }: TableProps<HTMLTableSectionElement>) => {
   return (
     <TableHeadContext.Provider value={{ variant: 'head' }}>
-      <thead className="lubycon-table__head">{children}</thead>
+      <thead className={classnames('lubycon-table__head', className)} {...props}>
+        {children}
+      </thead>
     </TableHeadContext.Provider>
   );
 };

--- a/ui-kit/src/components/Table/TableRow.tsx
+++ b/ui-kit/src/components/Table/TableRow.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { TableProps } from './index';
+import classnames from 'classnames';
+import { TableProps } from './props';
 
-const TableRow = ({ children }: TableProps) => {
-  return <tr className="lubycon-table__row">{children}</tr>;
+const TableRow = ({ children, className, ...props }: TableProps<HTMLTableRowElement>) => {
+  return (
+    <tr className={classnames('lubycon-table__row', className)} {...props}>
+      {children}
+    </tr>
+  );
 };
 
 export default TableRow;

--- a/ui-kit/src/components/Table/index.tsx
+++ b/ui-kit/src/components/Table/index.tsx
@@ -1,12 +1,13 @@
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 import classnames from 'classnames';
+import { TableProps } from './props';
 
-export interface TableProps extends Omit<HTMLAttributes<HTMLTableElement>, 'align' | 'bgcolor'> {
-  align?: 'left' | 'center' | 'right';
-}
-
-const Table = ({ children }: TableProps) => {
-  return <table className={classnames('lubycon-table', 'lubycon-shadow--2')}>{children}</table>;
+const Table = ({ children, className, ...props }: TableProps<HTMLTableElement>) => {
+  return (
+    <table className={classnames('lubycon-table', 'lubycon-shadow--2', className)} {...props}>
+      {children}
+    </table>
+  );
 };
 
 export default Table;

--- a/ui-kit/src/components/Table/props.ts
+++ b/ui-kit/src/components/Table/props.ts
@@ -1,0 +1,9 @@
+import { HTMLAttributes } from 'react';
+import { Combine } from 'src/types/utils';
+
+export type TableProps<T> = Combine<
+  Omit<HTMLAttributes<T>, 'align' | 'bgcolor'>,
+  {
+    align?: 'left' | 'center' | 'right';
+  }
+>;

--- a/ui-kit/src/components/Tooltip/TooltipBody.tsx
+++ b/ui-kit/src/components/Tooltip/TooltipBody.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, Ref } from 'react';
 import classnames from 'classnames';
 import Text from '../Text';
+import { CombineElementProps } from 'src/types/utils';
 
 export type TooltipArrowDirection =
   | 'top-left'
@@ -12,12 +13,15 @@ export type TooltipArrowDirection =
   | 'bottom-center'
   | 'bottom-right';
 
-interface Props {
-  children: string;
-  arrowDirection: TooltipArrowDirection;
-}
+type Props = CombineElementProps<
+  'div',
+  {
+    children: string;
+    arrowDirection: TooltipArrowDirection;
+  }
+>;
 const TooltipBody = forwardRef(function TooltipBody(
-  { children, arrowDirection }: Props,
+  { children, arrowDirection, className, ...props }: Props,
   forwardedRef: Ref<HTMLDivElement>
 ) {
   return (
@@ -25,9 +29,11 @@ const TooltipBody = forwardRef(function TooltipBody(
       ref={forwardedRef}
       className={classnames(
         'lubycon-tooltip__body',
-        `lubycon-tooltip__body--arrow-${arrowDirection}`
+        `lubycon-tooltip__body--arrow-${arrowDirection}`,
+        className
       )}
       tabIndex={-1}
+      {...props}
     >
       <Text typography="caption">{children}</Text>
     </div>

--- a/ui-kit/src/components/Tooltip/index.tsx
+++ b/ui-kit/src/components/Tooltip/index.tsx
@@ -1,17 +1,22 @@
 import React, { cloneElement, ReactElement, useState, useMemo, useCallback } from 'react';
 import { animated, useSpring } from 'react-spring';
 import { Portal } from 'src/contexts/Portal';
+import { CombineElementProps } from 'src/types/utils';
 import TooltipBody from './TooltipBody';
 import { OffsetPosition, TooltipElementSize, TooltipPosition } from './types';
 import { getArrowDirection, getTooltipPosition } from './utils';
 
-interface Props {
-  show: boolean;
-  children: ReactElement;
-  message: string;
-  position?: TooltipPosition;
-}
-const Tooltip = ({ show, children, message, position = 'top-center' }: Props) => {
+type Props = CombineElementProps<
+  'div',
+  {
+    show: boolean;
+    children: ReactElement;
+    message: string;
+    position?: TooltipPosition;
+  }
+>;
+
+const Tooltip = ({ show, children, message, position = 'top-center', ...props }: Props) => {
   const [tooltipSize, setTooltipSize] = useState<TooltipElementSize>({ width: 0, height: 0 });
   const [tooltipOffset, setTooltipOffset] = useState<OffsetPosition>({
     top: -1,
@@ -52,7 +57,7 @@ const Tooltip = ({ show, children, message, position = 'top-center' }: Props) =>
           className="lubycon-tooltip__positioner"
           style={{ ...tooltipOffset, ...animation }}
         >
-          <TooltipBody ref={tooltipRef} arrowDirection={arrowDirection}>
+          <TooltipBody ref={tooltipRef} arrowDirection={arrowDirection} {...props}>
             {message}
           </TooltipBody>
         </animated.div>


### PR DESCRIPTION
## 변경사항

### 업데이트
- 모든 컴포넌트들이 HTMLAttributes를 상속받도록 변경하고, `className` 과 `...props` 를 컴포넌트에 주입받습니다.
- Emotion, Tailwind CSS와 같이 CSS 클래스 기반으로 작동하는 녀석들을 함께 사용하기 위함.
- 
### 기타
- 슬랙 노티를 주는 깃헙 액션을 추가하였습니다. [노션 문서](https://www.notion.so/lubycon/PR-8f5fe3ff8f0e4d7d8c77ab5a0fed2238)를 참고해주세요!

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
전부 `className` 과 `props`를 주입하는 변경사항이기는 한데, `Table` 컴포넌트 같은 경우는 프로퍼티 타입 정의도 조금 바꿨습니다. 요 부분 신경써서 봐주시면 좋을 듯!
