### PR TITLE
fix: vscode에서 typescript 모듈을 찾지 못하는 이슈 수정 [skip ci]

### DIFF
--- a/.github/workflows/alpha-storybook-publish.yml
+++ b/.github/workflows/alpha-storybook-publish.yml
@@ -3,7 +3,7 @@ name: Publish Alpha Storybook
 on:
   push:
     branches:
-      - master
+      - main
       - alpha
 
 jobs:

--- a/.github/workflows/deploy-ui-kit-lib.yml
+++ b/.github/workflows/deploy-ui-kit-lib.yml
@@ -3,7 +3,7 @@ name: Release UI Kit
 on:
   push:
     branches:
-      - master
+      - main
       - alpha
       - beta
 

--- a/.github/workflows/live-storybook-publish.yml
+++ b/.github/workflows/live-storybook-publish.yml
@@ -3,7 +3,7 @@ name: Publish Live Storybook
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   storybook-publish:

--- a/src/components/Tabs/TabsItem.tsx
+++ b/src/components/Tabs/TabsItem.tsx
@@ -15,9 +15,8 @@ function TabItem(
   { children, disabled = false, value = String(children), className, onClick, ...props }: Props,
   forwardedRef: Ref<HTMLDivElement>
 ) {
-  const { selectedValue, onSelect, indicatorPosition, setIndicatorPosition } = useContext(
-    TabsContext
-  );
+  const { selectedValue, onSelect, indicatorPosition, setIndicatorPosition } =
+    useContext(TabsContext);
   const isSelected = selectedValue === value;
   const internalRef = useRef<HTMLDivElement | null>(null);
 


### PR DESCRIPTION
## 변경사항
- pnpify를 설치하여 IDE에서 typescript 모듈을 찾지 못하는 이슈를 수정합니다
- CI/CD 트리거가 `master` 브랜치에 잡혀있는 것을 `main`으로 변경합니다.


## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇‍♂️
