### PR TITLE
Feat/use element size

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -3,8 +3,8 @@ import { CombineElementProps } from 'src/types/utils';
 import classnames from 'classnames';
 import Icon from '../Icon';
 import Text from '../Text';
-import { useResizeObserver } from 'src';
 import { colors } from 'src/constants/colors';
+import { useElementSize } from 'src';
 
 type Props = CombineElementProps<
   'div',
@@ -22,16 +22,11 @@ const Accordion = forwardRef<HTMLDivElement, Props>(function Accordion(
 ) {
   const [open, setOpen] = useState(defaultOpen);
   const contentRef = useRef<HTMLDivElement>(null);
-  const [bodyHeight, setBodyHeight] = useState(0);
+  const { height: bodyHeight } = useElementSize(contentRef);
 
   const toggleContentOpen = () => {
     setOpen((state) => !state);
   };
-
-  const updateContentHeight = () =>
-    setBodyHeight(contentRef.current?.getBoundingClientRect().height ?? 0);
-
-  useResizeObserver(contentRef, updateContentHeight);
 
   useEffect(() => {
     onChange?.(open);

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,8 +1,6 @@
-import { RefObject, useEffect, useState } from 'react';
+import { RefObject, useMemo } from 'react';
 
-type ElementSize = Omit<IntersectionObserverEntry['boundingClientRect'], 'toJSON'>;
-
-const DEFAULT_CASE: ElementSize = {
+const DEFAULT_CASE = {
   top: 0,
   left: 0,
   right: 0,
@@ -14,22 +12,12 @@ const DEFAULT_CASE: ElementSize = {
 };
 
 function useElementSize(ref: RefObject<HTMLElement>) {
-  const [elementSize, setElementSize] = useState<ElementSize>(DEFAULT_CASE);
-
-  useEffect(() => {
-    if (ref.current === null) {
-      return;
+  return useMemo(() => {
+    if (!ref.current) {
+      return DEFAULT_CASE;
     }
-    const resizeObserver = new IntersectionObserver((entries) => {
-      setElementSize(entries[0].boundingClientRect);
-    });
-    resizeObserver.observe(ref.current);
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [ref]);
-
-  return elementSize;
+    return ref.current?.getBoundingClientRect();
+  }, [ref.current]);
 }
 
 export default useElementSize;

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,0 +1,35 @@
+import { RefObject, useEffect, useState } from 'react';
+
+type ElementSize = Omit<IntersectionObserverEntry['boundingClientRect'], 'toJSON'>;
+
+const DEFAULT_CASE: ElementSize = {
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+};
+
+function useElementSize(ref: RefObject<HTMLElement>) {
+  const [elementSize, setElementSize] = useState<ElementSize>(DEFAULT_CASE);
+
+  useEffect(() => {
+    if (ref.current === null) {
+      return;
+    }
+    const resizeObserver = new IntersectionObserver((entries) => {
+      setElementSize(entries[0].boundingClientRect);
+    });
+    resizeObserver.observe(ref.current);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [ref]);
+
+  return elementSize;
+}
+
+export default useElementSize;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export { default as useProgress } from './hooks/useProgress';
 export { default as useResizeObserver } from './hooks/useResizeObserver';
 export { useOverlay } from './contexts/Overlay';
 export { default as TransitionMotion } from './components/TransitionMotion';
+export { default as useElementSize } from './hooks/useElementSize';


### PR DESCRIPTION
> 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요!

## 변경사항
- useElementSize 추가

## 디자인 시안 링크
디자인 시안 링크를 첨부해주세요!

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
- 옵저버 폴리필 모듈 대신 인터섹션옵저버 그대로 사용해도 괜찮을까요?
  - 기존에 적용된 resizeObserver 폴리필 사용하려고 했는데,
폴리필 옵저버가 반환하는 높이가 패딩값을 제외한 값이더라구요.
그래서 우선은 인터섹션옵저버로 적용을 해보았습니다

- 리사이즈 옵저버랑 거의 동일한 것도 조금 걸리는데, 뭔가 재사용성 높은 형태로 쓸 수 있지 않을까? 그런 생각도 좀 들었습니다