### PR TITLE
chore: github notifier 버전을 2.0.0으로 업데이트 [skip ci]

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -1,5 +1,5 @@
-name: PR Slack Notification
-on: [pull_request]
+name: PR Notification
+on: [pull_request, pull_request_review, pull_request_review_comment]
 
 jobs:
   create-pull-request:
@@ -9,9 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Fire Notification
-        uses: Lubycon/github-reviewer-slack-noti-action@v1.6.0
+        uses: Lubycon/github-reviewer-noti-action@v2.0.0
         with:
-          slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
-          channel-id: C01TJJY15BP
           mattermost-webhook: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
## 변경사항
매터모스트로 PR 노티를 줄 수 있도록 notifier의 버전을 `2.0.0`으로 업데이트 합니다.

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 