### PR TITLE
Feat: useScroll 훅 추가

### DIFF
--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -1,5 +1,11 @@
 import { RefObject, useEffect } from 'react';
 
+/**
+ * 컴포넌트에 스크롤 이벤트를 추가하는 hook입니다.
+ * useEffect dependency로 hook의 인자인 ref, scrollCallback을 포함하고 있어
+ * ref, scrollCallback의 레퍼런스가 변경 될 때마다 스크롤 이벤트가 바인딩됩니다.
+ * 이 부분을 참고하셔서 성능이슈가 발생하지 않도록 잘 관리해주세요.
+ */
 const useScroll = (ref: RefObject<HTMLElement>, scrollCallback: () => void) => {
   useEffect(() => {
     if (ref.current === null) {

--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -1,0 +1,14 @@
+import { RefObject, useEffect } from 'react';
+
+const useScroll = (ref: RefObject<HTMLElement>, scrollCallback: () => void) => {
+  useEffect(() => {
+    if (ref.current === null) {
+      return;
+    }
+
+    ref.current.addEventListener('scroll', scrollCallback);
+    return () => ref.current?.removeEventListener('scroll', scrollCallback);
+  }, [ref]);
+};
+
+export default useScroll;

--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -6,9 +6,9 @@ const useScroll = (ref: RefObject<HTMLElement>, scrollCallback: () => void) => {
       return;
     }
 
-    ref.current.addEventListener('scroll', scrollCallback);
+    ref.current.addEventListener('scroll', scrollCallback, { passive: true });
     return () => ref.current?.removeEventListener('scroll', scrollCallback);
-  }, [ref]);
+  }, [ref, scrollCallback]);
 };
 
 export default useScroll;


### PR DESCRIPTION
## 변경사항
ref 로 넘겨준 엘리먼트에 scroll 이벤트를 추가할 수있는 hook을 만들었습니다.

- 사용법
```javascript
const Test = () => {
  const refEl = useRef<HTMLDivElement>(null);
  const handleScroll = () => {
    console.log("scrollin' rollin' rollin'");
  };
  useScroll(refEl, handleScroll);
  return (
    <div
      ref={refEl}
      style={{ width: "14px", height: "10px", overflow: "auto" }}
    >
      후후후후후후후후
    </div>
  );
};
```